### PR TITLE
Fix careers page social media preview

### DIFF
--- a/content/pages/careers.md
+++ b/content/pages/careers.md
@@ -1,4 +1,5 @@
 Title: Careers at Shovels
+Description: Join our team building the future of construction intelligence. Engineers here command AI agents that write production code across distributed systems, data pipelines, and APIs.
 slug: careers
 
 <!-- hero -->


### PR DESCRIPTION
Adds missing Description metadata to careers page for proper social media card display.

**Before:** Shows "No Current Openings" from old cached data
**After:** Shows updated description about AI-native engineering position

Note: Social media platforms (LinkedIn, Twitter, Slack, etc.) may cache the old preview for a while. Use their debugging tools to force refresh if needed.