### PR TITLE
Fix duplicate index.html URLs in Google Search Console

### DIFF
--- a/themes/shovels/templates/base.html
+++ b/themes/shovels/templates/base.html
@@ -68,6 +68,9 @@
   {% endif %}
   <!-- ... other feed links moved to bottom ... -->
   
+  <!-- Canonical URL -->
+  <link rel="canonical" href="{{ SITEURL }}/{% if article %}{{ article.url }}{% elif page %}{{ page.url }}{% endif %}" />
+
   <!-- Social meta tags -->
   <meta property="og:type" content="{% if article %}article{% else %}website{% endif %}" />
   <meta property="og:url" content="{{ SITEURL }}{% if article %}{{ article.url }}{% elif page %}{{ page.url }}{% endif %}" />


### PR DESCRIPTION
## Summary

- Adds explicit canonical URL tags to `base.html` template to resolve duplicate page indexing in Google Search Console

## Problem

Google Search Console was showing duplicate pages being indexed - both the clean folder URLs (e.g., `/blog/article-slug/`) and explicit `/index.html` URLs (e.g., `/blog/article-slug/index.html`).

**Root cause:** The `pelican-seo` plugin generates BreadcrumbList structured data that includes explicit `/index.html` paths as separate list items, which Google discovers and indexes.

## Solution

Added canonical URL tags to the base template that explicitly tell Google which URL version is preferred:

```html
<link rel="canonical" href="{{ SITEURL }}/{% if article %}{{ article.url }}{% elif page %}{{ page.url }}{% endif %}" />
```

This generates clean canonical URLs:
- **Articles:** `https://www.shovels.ai/blog/{slug}/`
- **Pages:** `https://www.shovels.ai/{slug}`

## Expected Outcome

Over time as Google re-crawls the site and respects the canonical tags, the duplicate `/index.html` URLs should be consolidated with their canonical counterparts, resolving the duplicate content issue in Search Console.

## Test plan

- [ ] Build site locally with `pelican -lr` and verify canonical tags appear in page source
- [ ] Deploy to production
- [ ] Monitor Google Search Console over next few weeks for consolidation of duplicate URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)