### PR TITLE
Remove Jinja2 block tags from page content files

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -2,7 +2,6 @@ Title: About Shovels, Inc.
 Description: The intelligence layer for the built world. Shovels captures the first signal of construction—using AI to turn fragmented permit data into Shovel-ready intelligence.
 slug: about
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: about
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 pb-32 pt-36 sm:pt-60 lg:px-8 lg:pt-32">

--- a/content/pages/api.md
+++ b/content/pages/api.md
@@ -2,7 +2,6 @@ Title: Building Contractor and Permit API
 Description: Access the first signal of construction through our API. Shovel-ready intelligence from thousands of municipalities, delivered via REST API with enhanced geo-search and lightning-fast response times.
 slug: api
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: api
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 py-32 sm:py-40 lg:px-8">

--- a/content/pages/audiences.md
+++ b/content/pages/audiences.md
@@ -2,7 +2,6 @@ Title: Activate Audiences with Permit Data
 Description: Use building permit data to create unique home remodel and improvement audiences.
 slug: audiences
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: audiences
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 py-32 sm:py-40 lg:px-8">

--- a/content/pages/building-materials.md
+++ b/content/pages/building-materials.md
@@ -2,7 +2,6 @@ Title: Leads for building materials and equipment suppliers and building product
 Description: Shovels helps building material suppliers find and connect with commercial contractors through permit intelligence, CRM enhancement, and fraud prevention.
 slug: building-materials
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: building-materials
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 py-32 sm:py-40 lg:px-8">

--- a/content/pages/chuck.md
+++ b/content/pages/chuck.md
@@ -2,7 +2,6 @@ Title: Chuck AI Agent - Early Access Waitlist
 Description: Join the waitlist for Chuck, Shovels' revolutionary AI agent that transforms building permit data into actionable insights. Get instant construction reports, predictive analytics, and market intelligence with natural language queries.
 slug: chuck
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="chuck-pattern" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: chuck
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#chuck-pattern)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <svg viewBox="0 0 1024 1024" class="absolute left-1/2 top-1/2 -z-10 size-[64rem] -translate-y-1/2 [mask-image:radial-gradient(closest-side,white,transparent)] sm:left-full sm:-ml-80 lg:left-1/2 lg:ml-0 lg:-translate-x-1/2 lg:translate-y-0" aria-hidden="true">

--- a/content/pages/climate.md
+++ b/content/pages/climate.md
@@ -2,7 +2,6 @@ Title: Building Electrification permits and contractors
 Description: Track solar, EV charger, heat pump HVAC, water heater, and battery installations to build lead lists and create installer networks based on contractor service areas.
 slug: climate
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: climate
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 py-24 sm:py-24 lg:px-8">

--- a/content/pages/contact-research.md
+++ b/content/pages/contact-research.md
@@ -2,7 +2,6 @@ Title: Contact Shovels For Research
 Description: Access comprehensive building permit data for academic research, policy analysis, and institutional studies. Shovels provides researchers with clean, structured datasets to support housing, construction, and urban development research.
 slug: contact/research
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: contact/research
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate">
   <div class="mx-auto grid max-w-7xl grid-cols-1 lg:grid-cols-2">

--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -2,7 +2,6 @@ Title: Contact Shovels
 Description: Connect with Shovels to learn how our enterprise-ready contractor intelligence solutions can power your sales and marketing workflows.
 slug: contact
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: contact
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate">
   <div class="mx-auto grid max-w-7xl grid-cols-1 lg:grid-cols-2">

--- a/content/pages/data-feed.md
+++ b/content/pages/data-feed.md
@@ -2,7 +2,6 @@ Title: Building Contractor and Permit Data Feed
 Description: Get nationwide building permit and contractor data directly in your Snowflake, Big Query, or Databricks environment with automatic updates and flexible delivery options.
 slug: data-feed
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: data-feed
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 pt-32 pb-24 sm:py-40 lg:px-8">

--- a/content/pages/gis.md
+++ b/content/pages/gis.md
@@ -2,7 +2,6 @@ Title: Geospatial Building Permit Intelligence
 Description: Access building permit data as geospatial objects for site selection, market intelligence, and competitive intelligence. Compatible with Esri ArcGIS and other geospatial platforms.
 slug: gis
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: gis
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 py-32 sm:py-40 lg:px-8">

--- a/content/pages/home-services.md
+++ b/content/pages/home-services.md
@@ -2,7 +2,6 @@ Title: Get all the data on every building contractor
 Description: Discover new contractors and enrich existing contractors using the most comprehensive building contractor and permit dataset in the US.
 slug: home-services
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: home-services
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 py-32 sm:py-40 lg:px-8">

--- a/content/pages/permit-database.md
+++ b/content/pages/permit-database.md
@@ -2,7 +2,6 @@ Title: Building Permit Database
 Description: Explore nationwide building permits with advanced filtering and intelligent contractor matching through our powerful web software and modern interface.
 slug: permit-database
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: permit-database
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 py-32 sm:py-40 lg:px-8">

--- a/content/pages/real-estate.md
+++ b/content/pages/real-estate.md
@@ -2,7 +2,6 @@ Title: Find the best building sites using building permits
 Description: Improve site selection with our Neighborhood Vitality Index (NVI) and permit approval speed metrics to identify the most actively improving areas.
 slug: real-estate
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: real-estate
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 py-32 sm:py-40 lg:px-8">

--- a/content/pages/software.md
+++ b/content/pages/software.md
@@ -2,7 +2,6 @@ Title: Building Permit Data for Property Tech Software
 Description: Enhance your property tech platform with clean, AI-processed building permit data. Access contractor history, service areas, and decision maker contact information through our API or database.
 slug: software
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: software
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 py-32 sm:py-40 lg:px-8">

--- a/content/pages/team.md
+++ b/content/pages/team.md
@@ -2,7 +2,6 @@ Title: The team behind Shovels
 slug: team
 Description: Meet the talented team behind Shovels - experienced leaders in proptech, data engineering, and growth who are revolutionizing how companies connect with contractors.
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ Description: Meet the talented team behind Shovels - experienced leaders in prop
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="pt-24 sm:pt-32">
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/content/pages/telcomm.md
+++ b/content/pages/telcomm.md
@@ -2,7 +2,6 @@ Title: Telecommunications Infrastructure Intelligence | Building Permit Data for
 Description: Optimize fiber deployment and network expansion using building permit data. Track competitor activity, identify high-growth markets, and streamline telecom infrastructure planning across 2,000+ jurisdictions.
 slug: telecommunications
 
-{% block background_pattern %}
 <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
   <defs>
     <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
@@ -14,7 +13,6 @@ slug: telecommunications
   </svg>
   <rect width="100%" height="100%" stroke-width="0" fill="url(#83fd4e5a-9d52-42fc-97b6-718e5d7ee527)" />
 </svg>
-{% endblock background_pattern %}
 
 <div class="relative isolate overflow-hidden">
   <div class="mx-auto max-w-7xl px-6 py-32 sm:py-40 lg:px-8">


### PR DESCRIPTION
## Summary
- Removes `{% block background_pattern %}` and `{% endblock background_pattern %}` tags from 16 markdown content files
- These Jinja2 block tags don't work in markdown files (only in template files) and were rendering as literal text on the live site
- The SVG background patterns remain intact - only the non-functional block wrapper tags are removed

## Root Cause
The block tags were introduced in PR #25 (Jan 6, 2025) during the site redesign. They work correctly in template files like `index.html` and `archives.html`, but were mistakenly copy-pasted into markdown content files where Pelican doesn't process Jinja2 blocks.

## Affected Pages
- /about
- /api
- /audiences
- /building-materials
- /chuck
- /climate
- /contact
- /contact-research
- /data-feed
- /gis
- /home-services
- /permit-database
- /real-estate
- /software
- /team
- /telcomm

## Test plan
- [x] Verified no `{% block` tags remain in content files
- [x] Site builds without errors
- [x] Output HTML no longer contains literal `{% block background_pattern %}` text

🤖 Generated with [Claude Code](https://claude.com/claude-code)