### PR TITLE
Update broken links and migrate Knowledge Base URLs

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -211,7 +211,7 @@ slug: about
     </div>
     <div class="mt-16 flex justify-center">
       <p class="relative rounded-full bg-gray-50 px-4 py-1.5 text-sm/6 text-gray-600 ring-1 ring-inset ring-gray-900/5">
-        <a href="{{ SITEURL }}/blog/?category=Case%20Study" class="font-semibold text-shovels-primary"><span class="absolute inset-0" aria-hidden="true"></span> Read our case studies <span aria-hidden="true">&rarr;</span></a>
+        <a href="/blog/?category=Case%20Study" class="font-semibold text-shovels-primary"><span class="absolute inset-0" aria-hidden="true"></span> Read our case studies <span aria-hidden="true">&rarr;</span></a>
       </p>
     </div>
   </div>

--- a/content/pages/climate.md
+++ b/content/pages/climate.md
@@ -149,7 +149,7 @@ slug: climate
             <p class="mt-5 line-clamp-3 text-sm/6 text-gray-600">The Shovels dataset and model can highlight key construction trends and patterns. In this blog, we discuss solar construction specifically due to the RE+ clean energy convention. Use Shovels to inform your construction company's business models and strategy.</p>
           </div>
           <div class="relative mt-8 flex items-center gap-x-4">
-            <img src="{{ SITEURL }}/theme/images/team/alex.svg" alt="Alex Brown" class="size-10 rounded-full bg-gray-100">
+            <img src="/theme/images/team/alex.svg" alt="Alex Brown" class="size-10 rounded-full bg-gray-100">
             <div class="text-sm/6">
               <p class="font-semibold text-gray-900">
                 <span class="absolute inset-0"></span>
@@ -180,7 +180,7 @@ slug: climate
             <p class="mt-5 line-clamp-3 text-sm/6 text-gray-600">We look at the impact of BayREN's initiatives on the Bay Area's energy upgrade trends, revealing a significant increase in heat pump installations by BayREN-affiliated contractors compared to a lesser focus on solar panel installations. It suggests that BayREN is strategically filling gaps in the building electrification market.</p>
           </div>
           <div class="relative mt-8 flex items-center gap-x-4">
-            <img src="{{ SITEURL }}/theme/images/team/ryan.svg" alt="Ryan Buckley" class="size-10 rounded-full bg-gray-100">
+            <img src="/theme/images/team/ryan.svg" alt="Ryan Buckley" class="size-10 rounded-full bg-gray-100">
             <div class="text-sm/6">
               <p class="font-semibold text-gray-900">
                 <span class="absolute inset-0"></span>
@@ -211,7 +211,7 @@ slug: climate
             <p class="mt-5 line-clamp-3 text-sm/6 text-gray-600">At Shovels, we provide developers with access to monthly EV charger installation data through our building permit API. This data reveals the tremendous growth and geographic distribution of EV charging infrastructure, with insights into the locations and companies involved. Understanding this data is crucial for businesses, developers, and governments to identify areas for expansion and to make informed decisions. With our API, developers can accurately map existing charger locations, analyze infrastructure, and even predict future demand for electric vehicles.</p>
           </div>
           <div class="relative mt-8 flex items-center gap-x-4">
-            <img src="{{ SITEURL }}/theme/images/team/ryan.svg" alt="Ryan Buckley" class="size-10 rounded-full bg-gray-100">
+            <img src="/theme/images/team/ryan.svg" alt="Ryan Buckley" class="size-10 rounded-full bg-gray-100">
             <div class="text-sm/6">
               <p class="font-semibold text-gray-900">
                 <span class="absolute inset-0"></span>

--- a/content/pages/newsletter-signup.md
+++ b/content/pages/newsletter-signup.md
@@ -14,6 +14,6 @@ slug: newsletter
     <p class="my-4 leading-8 text-lg"><strong>What's in it?</strong></p>
     <p class="my-4 leading-8 text-lg">This newsletter usually includes company and product updates, community events we're participating in, parterships, and anything else that we're excited about that month. Sometimes, we'll throw in special offers or discount codes too!</p>
     <p class="my-4 leading-8 text-lg"><strong>How else can I keep in touch with Shovels?</strong></p>
-    <p class="my-4 leading-8 text-lg">There's a ton of ways! Join our <a href="https://discord.gg/Nypja3cKDx" target="_blank">community Discord channel</a>, follow us on <a href="https://www.linkedin.com/company/shovels/" target="_blank">LinkedIn</a> or check out our <a href="https://github.com/shovelsai" target="_blank">Github</a>.</p>
+    <p class="my-4 leading-8 text-lg">There's a ton of ways! Join our <a href="https://discord.com/invite/Nypja3cKDx" target="_blank">community Discord channel</a>, follow us on <a href="https://www.linkedin.com/company/shovels/" target="_blank">LinkedIn</a> or check out our <a href="https://github.com/shovelsai" target="_blank">Github</a>.</p>
 </div>
 

--- a/content/posts/adu-2025.md
+++ b/content/posts/adu-2025.md
@@ -42,7 +42,7 @@ ADUs help cities add housing efficiently while creating flexible living arrangem
 
 - Generate passive income through monthly rental revenue, helping offset mortgage payments and property taxes.
 - Create flexible living space for family or caregivers, enabling [aging-in-place](https://www.aarp.org/livable-communities/housing/info-2019/accessory-dwelling-units-adus.html) and multi-generational housing solutions.
-- Boost property value with a legal rental unit, potentially increasing home equity by 20-30% according to [recent market analyses](https://www.notion.so/Ryan-Morgan-1-1-notes-25d5e14e7352808eb900f58e88c80093?pvs=21).
+- Boost property value with a legal rental unit, potentially increasing home equity by 20-30%.
 - Maximize underutilized property space like oversized yards, empty garages, or basement areas.
 - Gain housing flexibility for changing life circumstances without needing to move or sell.
 

--- a/content/posts/newsletter-apr-24.md
+++ b/content/posts/newsletter-apr-24.md
@@ -18,7 +18,7 @@ Last month was a planning month for us. Luka and Petra joined me in California a
 All of this mingling and meeting helped us set the stage for the next phase of Shovels. We're growing up a bit. I'll explain what I mean. 
 
 *   Shovels V2 is in the works! I'll share more about what exactly this means. In short: a whole bunch of stuff you've told us you need.
-*   Because the V2 is our focus, I've neglected our iOS app development. It's just so V1. We'll get it launched in prep for V2, but it'll take us another month. In the meantime, we've been updating [the Android app](https://play.google.com/store/apps/details?id=com.shovels.shovels1).  
+*   Because the V2 is our focus, I've neglected our iOS app development. It's just so V1. We'll get it launched in prep for V2, but it'll take us another month.  
 *   PSA: We can now share 130M permits and 2.5M contractors directly into your Snowflake, Big Query, or Databricks account. This makes some data scientists VERY happy. 
 *   Ever wanted a list of every building permit jurisdiction? [We released one](https://www.shovels.ai/blog/list-of-all-building-permit-jurisdictions/). We're working on a V2 of that, too. It will have at least 5,000 more jurisdictions!
 *   Check out how [Beam](https://www.trybeam.com/), one of our happy customers, is using Shovels to [reach out to contractors](https://www.shovels.ai/blog/case-study-revolutionizing-lead-generation-for-beam/). 

--- a/content/posts/newsletter-aug-24.md
+++ b/content/posts/newsletter-aug-24.md
@@ -28,7 +28,7 @@ Okay, enough looking backward -- here's what's coming up next!
 - We will have a booth at [Blueprint](https://blueprintvegas.com/) in Las Vegas from Sept 17-19. Find us and say hi!
 - We won't have a booth at [RE+](https://www.re-plus.com/) in Anaheim on Sept 9-12, but we will be walking around and meeting a lot of people (and a few of our customers) who do have booths. Reach out if you'll be there!
 - We'll also be in NYC for some of [Climate Week](https://www.climateweeknyc.org/) from Sept 22-29. Lots of climate capital and tech will converge there and we are ready for it.
-- For those of you new to this newsletter, don't forget to [find us on Discord](https://discord.gg/Nypja3cKDx). We're just getting started with our new online Shovels community.
+- For those of you new to this newsletter, don't forget to [find us on Discord](https://discord.com/invite/Nypja3cKDx). We're just getting started with our new online Shovels community.
 - On the tech front, we added *start_date* and *end_date* to our database table shares and they'll launch in the API this week. It's a much better way to filter and query.
 - We added *primary_email* and *primary_phone* to the contractors table. Many of you asked for this. We delivered!
 - We also made more progress on contractor de-duplication. This will continue to be a work in progress -- and we will continue to be the very best at it.

--- a/content/posts/newsletter-feb-23.md
+++ b/content/posts/newsletter-feb-23.md
@@ -74,9 +74,7 @@ If there's one piece of startup advice that I hear over and over again, it's thi
 
 ### Asks
 
-* We're hiring! We'd appreciate any candidate intros. Feel free to share these job descriptions: 
-  * [Marketer](https://broadleaf-leech-f9b.notion.site/Growth-Marketer-4a35d1c91875485eaee25c72b77fedf1)
-  * [Data Engineer](https://broadleaf-leech-f9b.notion.site/Data-Engineer-8c88bef8282d4d0ebdf74178c5e737d4)
+* We're hiring! We'd appreciate any candidate intros. Check out our [careers page](https://www.shovels.ai/careers) for open positions.
 * Intros to construction loan people. I want more interviews. 
 * Intros to developers who do 10+ projects at a time in the Bay Area. I need to learn more from this segment. 
 

--- a/content/posts/newsletter-feb-24.md
+++ b/content/posts/newsletter-feb-24.md
@@ -17,7 +17,7 @@ I've been looking forward to writing this newsletter for more than a year.
 
 *   Anyone can register at [https://app.shovels.ai](https://app.shovels.ai)! All you need is an email address. Here's [a blog post](https://www.shovels.ai/blog/how-to-use-the-shovels-app/) about it!
 *   It's free for now. There still are a few bugs I know about, and you'll find a few more. It's free because I want your feedback. I figure we'll start charging for access before the next newsletter.
-*   Our [custom GPT](https://chatgpt.com/g/g-zXFhOF8SP-shovels-ai) is getting LOTS of use too. Who knew making building permit and contractor data accessible would be such a useful thing? (We did 😇)[](https://www.shovels.ai/blog/how-to-use-the-shovels-api/)
+*   Our [custom GPT](https://chatgpt.com/g/g-zXFhOF8SP-shovels-ai) is getting LOTS of use too. Who knew making building permit and contractor data accessible would be such a useful thing? (We did 😇)
 
 The case for software
 =====================

--- a/content/posts/newsletter-jan-24 .md
+++ b/content/posts/newsletter-jan-24 .md
@@ -17,7 +17,7 @@ With that out of the way, let's get down to business!
 
 *   With the help of ChatGPT, we are officially putting the AI in Shovels.ai. Preview [our custom GPT](https://chatgpt.com/g/g-zXFhOF8SP-shovels-ai) before it goes behind a paywall later this month. Tell it to look up some permits! 
 *   We added a bunch of new contractors and then de-duplicated them so searching by name is less confusing. We also improved the way permits are queried by zip code!
-*   And more things to do with permit data: calculate permit approval times (soon with even more granularity). [](https://www.shovels.ai/blog/how-to-use-the-shovels-api/)
+*   And more things to do with permit data: calculate permit approval times (soon with even more granularity). 
 
 ✨ Have you heard of ChatGPT? ✨
 ==============================

--- a/content/posts/newsletter-july-24.md
+++ b/content/posts/newsletter-july-24.md
@@ -21,7 +21,7 @@ We have new partnerships. We have a public Discord server. On the data side, we'
 *   And another partnership: [Deep Sync](https://deepsync.com/) for targeting homeowners with ads based on their permit history. I couldn't fit this one into the previous bullet. 
 *   We'll be at the [Esri User Conference](https://www.esri.com/en-us/about/events/uc/overview) in San Diego next week! Reply or join our Discord (see below) if you can meet up. 
 *   How about Austin in March 2025? We need ideas for a SXSW panel. We'll be your data partner. [Submissions are due](https://panelpicker.sxsw.com/) on July 21.
-*   Speaking of reaching out, you can now [chat us up on Discord](https://discord.gg/Nypja3cKDx). We launched a public server! [Hop into our Discord](https://discord.gg/Nypja3cKDx) to chat with us about permits, contractors, data science, or the blink-182 summer concert tour (I went and it was EPIC 🤘)
+*   Speaking of reaching out, you can now [chat us up on Discord](https://discord.com/invite/Nypja3cKDx). We launched a public server! [Hop into our Discord](https://discord.com/invite/Nypja3cKDx) to chat with us about permits, contractors, data science, or the blink-182 summer concert tour (I went and it was EPIC 🤘)
 *   Our customers love our transparency. Here's a big heaping spoonful of it: We released a **very** detailed [Shovels Coverage Dashboard](https://shovels.metabaseapp.com/public/dashboard/0573503d-88ac-4ba4-a723-346b55de482b). Now you can see exactly where we have (and don't have) building permit and contractor data! 
 *   Our nationwide AI-driven permit classifications are available to our database and report customers. These are REALLY GOOD. I know because our most skeptical customers said so. We'll roll them out to the API and web app shortly. 
 
@@ -88,4 +88,4 @@ It may not look like much, but this represents a TON of hard work -- pulling dat
 
 That's what I'm looking forward to talking about next week at the Esri conference.
 
-And if you want to nerd out about it online, now you can [find us on Discord](https://discord.gg/Nypja3cKDx) 🤓
+And if you want to nerd out about it online, now you can [find us on Discord](https://discord.com/invite/Nypja3cKDx) 🤓

--- a/content/posts/newsletter-mar-24.md
+++ b/content/posts/newsletter-mar-24.md
@@ -15,7 +15,7 @@ Last month we launched [our web app](https:/app.shovels.ai). This month we're of
 
 And we want to meet you IRL.
 
-*   A few days ago we launched an [Android app](https://play.google.com/store/apps/details?id=com.shovels.shovels1). You can find it now on Google Play. Next month we'll launch on the Apple App Store, too. 
+*   A few days ago we launched an Android app. You can find it now on Google Play. Next month we'll launch on the Apple App Store, too. 
 *   Let's meet! The Shovels team will be in SF from March 18-19 and LA on March 21. We'll come to your office. 
 *   Lots more data and API enhancements. Details below.
 *   We can now push permit and contractor tables into Big Query, Snowflake, Databricks, S3, GCS, and Azure! 
@@ -29,7 +29,7 @@ It's because of Flutter that we can build a web app and a mobile app at the same
 
 You could say it gives us mobility. We're moving fast! 
 
-Here's a few screenshots of our Android app. Get it on [Google Play now](https://play.google.com/store/apps/details?id=com.shovels.shovels1).
+Here's a few screenshots of our Android app. Get it on Google Play.
 
 (We could have launched iOS too, but I gotta save _something_ for April.)
 

--- a/content/posts/newsletter-mar-25.md
+++ b/content/posts/newsletter-mar-25.md
@@ -14,7 +14,7 @@ image: /images/vegas.jpeg
 You know what we all need right now? A shorter newsletter. Quick and to the point. Punchy! That’s what we’re doing this month. 
 
 - Check out our [SF Climate Week Energy API Hackathon](https://lu.ma/pwh9o2e8?tk=jYxRHS)!
-- [Our Discord](https://discord.gg/Nypja3cKDx) has a new channel for all you Clay sales hackers
+- [Our Discord](https://discord.com/invite/Nypja3cKDx) has a new channel for all you Clay sales hackers
 - A few cool Shovels Online and API updates and a preview of what’s coming
 - We’re pushing parcels in our monthly “Things to do with permits” feature
 
@@ -49,11 +49,11 @@ It’s [free to sign up](https://lu.ma/pwh9o2e8?tk=jYxRHS)!
 
 I’m seeing more clever marketing and sales people diving into sales hacking. The AI toolkit makes it easy, and we’re here for it. 
 
-We want to build a community specifically for property, construction, and building trades sales hackers. Since we already have [a Shovels Discord server](https://discord.gg/Nypja3cKDx) (which has also been sorta blowing up recently) we created a new channel, #sales-hackers, on it.
+We want to build a community specifically for property, construction, and building trades sales hackers. Since we already have [a Shovels Discord server](https://discord.com/invite/Nypja3cKDx) (which has also been sorta blowing up recently) we created a new channel, #sales-hackers, on it.
 
 I will be nudging our Clay and Shovels API friends over there. The purpose is to share clever ways to use Clay, OpenAI, Shovels, Apollo, and other data providers to automate outreach in the property and construction industries. 
 
-I hope you’ll [join us](https://discord.gg/Nypja3cKDx)! 
+I hope you’ll [join us](https://discord.com/invite/Nypja3cKDx)! 
 
 # 👩🏻‍💻 Recent tech updates
 

--- a/content/posts/newsletter-may-24.md
+++ b/content/posts/newsletter-may-24.md
@@ -19,7 +19,7 @@ Luka and I have known Betty for years and we knew she'd be perfect to lead our r
 
 That's top of mind as we move to make Shovels 33% better and grow 33% faster. Here's what's up!  
 
-*  We have a clickable prototype of V2. I need to schedule some [short 15 minute calls](https://shovels.pipedrive.com/scheduler/GXeGebUW/shovels-v2-prototype-test) to watch _you_ click through it. Trade 15 minutes for some permit data? [Let's chat!](https://shovels.pipedrive.com/scheduler/GXeGebUW/shovels-v2-prototype-test)
+*  We have a clickable prototype of V2. I need to schedule some [short 15 minute calls](https://www.shovels.ai/contact) to watch _you_ click through it. Trade 15 minutes for some permit data? [Let's chat!](https://www.shovels.ai/contact)
 *  Our new tagging system is almost ready for launch. Our first AI-enhanced tags will be live before the next newsletter! More on this process below.
 *  More jurisdictions, more duration calculations, and more contractor de-duplication was in our latest batch release, which was processed using way more automation.
 *  Because every day is Earth Day 🌱 we have a new [climate tech case study]({filename}case-carbon-free-homes.md), a new [climate tech one-pager]({static}/pdfs/Shovels_Climate.pdf), and identified over 14,000 contractors with green rebate program affiliations (more on this next month!)
@@ -36,7 +36,7 @@ So, here's the plot so far:
 - We released our nationwide building permit API in August 2023  
 - We followed that with a nationwide building contractor API in Nov 2023  
 - (Lost? Here's [what an API is]({filename}api-guide-1.md))  
-- Then we launched [a custom GPT]({filename}gpt-guide-1.md) and [a web app]({filename}app-guide-1.md) and [a mobile app](https://play.google.com/store/apps/details?id=com.shovels.shovels1)  
+- Then we launched [a custom GPT]({filename}gpt-guide-1.md) and [a web app]({filename}app-guide-1.md)  
 - Now we're making all ☝️ a lot better  
 - And Betty just joined to help me sell this stuff
 
@@ -50,7 +50,7 @@ We're going to give you the ability to look at the permit queue in any jurisdict
 
 We have a clickable prototype and before we really start building it, we'd love to watch you to try to use it.
 
-Can I get [15 mins of your time](https://shovels.pipedrive.com/scheduler/GXeGebUW/shovels-v2-prototype-test)? What you'll get in return is influence, our gratitude, and some free Shovels data.
+Can I get [15 mins of your time](https://www.shovels.ai/contact)? What you'll get in return is influence, our gratitude, and some free Shovels data.
 
 Here's the same sneak peak I shared last month.
 

--- a/content/posts/newsletter-oct-23.md
+++ b/content/posts/newsletter-oct-23.md
@@ -20,7 +20,7 @@ With that... back to permits. 
 *   Last month, I said we'd work on loading every state into the API. This month, I get to tell you it's done! Yay! 
 *   To celebrate this launch, we're making it easier to get API keys. You don't need to ask us first. Just register an account with [our sweet new app](https://app.shovels.ai) and get your API key 💪
 *   Don't know how to use an API? That's cool, for most of my life, I didn't either. I have a solution for you, too. Read below. 
-*   If you do like APIs, don't forget about our [pretty API docs](https://docs.shovels.ai/api-reference) 😍 and check out our [API starter guide](https://www.shovels.ai/blog/how-to-use-the-shovels-api/).[](https://www.shovels.ai/blog/how-to-use-the-shovels-api/)
+*   If you do like APIs, don't forget about our [pretty API docs](https://docs.shovels.ai/api-reference) 😍 and check out our [API introduction](https://docs.shovels.ai/docs/shovels-api-introduction).
 
 🇺🇸 The API is national 🇺🇸
 =============================
@@ -38,7 +38,7 @@ And across all of these permits we applied 33 unique "tags" in order to make it 
 **API wuh? 🤔**
 ===============
 
-Here's my attempt at writing the shortest-ever tutorial on how to use an API. We have a more detailed [tutorial on the blog](https://www.shovels.ai/blog/how-to-use-the-shovels-api/). 
+Here's my attempt at writing the shortest-ever tutorial on how to use an API. We have a more detailed [API introduction](https://docs.shovels.ai/docs/shovels-api-introduction) in our docs. 
 
 An API is like a set of defined questions you can ask a database using your favorite programming language. Each of these questions is called an "endpoint." 
 

--- a/content/posts/shovels-101-address-permit-history.md
+++ b/content/posts/shovels-101-address-permit-history.md
@@ -18,7 +18,7 @@ With the [Shovels API](https://docs.shovels.ai/api-reference/) in your toolbox, 
 
 If you don’t already have a **Shovels Web App** account (welcome!), then head over and setup a [Free Trial](https://app.shovels.ai). Go to the **Settings** page to get your API Key, read over our API Docs, and open your preferred terminal, shell, or editor. 
 
-For a more in-depth introduction to using our API, please check out our blog post guide on [How to use the Shovels API](https://www.shovels.ai/blog/how-to-use-the-shovels-api/). 
+For a more in-depth introduction to using our API, please refer to our [API documentation](https://docs.shovels.ai/docs/shovels-api-introduction). 
 
 This guide will assume a basic familiarity with cURL, JSON parsing, and our API schema. Example query snippets will use cURL, but our API docs have examples in a variety of other languages too.
 

--- a/themes/shovels/templates/base.html
+++ b/themes/shovels/templates/base.html
@@ -161,8 +161,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/theme/images/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/theme/images/favicon-16x16.png">
   <link rel="manifest" href="/theme/images/site.webmanifest">
-  <link rel="mask-icon" href="/theme/images/safari-pinned-tab.svg" color="#5bbad5">
-  
+    
 </body>
 
 </html>

--- a/themes/shovels/templates/footer.html
+++ b/themes/shovels/templates/footer.html
@@ -62,7 +62,7 @@
                 <a href="{{ SITEURL }}/blog" class="text-sm leading-6 hover:text-amber-500">Blog</a>
               </li>
               <li>
-                <a href="https://support.shovels.ai" class="text-sm leading-6 hover:text-amber-500">Knowledge Base</a>
+                <a href="https://docs.shovels.ai/docs/knowledge-base" class="text-sm leading-6 hover:text-amber-500">Knowledge Base</a>
               </li>
               <li>
                 <a href="https://love.shovels.ai/all" class="text-sm leading-6 hover:text-amber-500">Customer Testimonials</a>
@@ -77,7 +77,7 @@
                 <a href="https://docs.shovels.ai/" class="text-sm leading-6 hover:text-amber-500" target="_blank">Documentation Hub</a>
               </li>
               <li>
-                <a href="https://discord.gg/Nypja3cKDx" class="text-sm leading-6 hover:text-amber-600">Discord</a>
+                <a href="https://discord.com/invite/Nypja3cKDx" class="text-sm leading-6 hover:text-amber-600">Discord</a>
               </li>
             </ul>
           </div>
@@ -112,7 +112,7 @@
     </div>
     <div class="mt-16 border-t border-stone-200/10 pt-8 sm:mt-20 md:flex md:items-center md:justify-between lg:mt-24">
       <div class="flex space-x-6 md:order-2">
-        <a href="https://discord.gg/Nypja3cKDx" class="text-gray-400 hover:text-gray-500" target="_blank">
+        <a href="https://discord.com/invite/Nypja3cKDx" class="text-gray-400 hover:text-gray-500" target="_blank">
           <span class="sr-only">Discord</span>
           <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 512 512" aria-label="Discord" role="img" version="1.1" xmlns="http://www.w3.org/2000/svg">
             <path d="m386 137c-24-11-49.5-19-76.3-23.7c-.5 0-1 0-1.2.6c-3.3 5.9-7 13.5-9.5 19.5c-29-4.3-57.5-4.3-85.7 0c-2.6-6.2-6.3-13.7-10-19.5c-.3-.4-.7-.7-1.2-.6c-23 4.6-52.4 13-76 23.7c-.2 0-.4.2-.5.4c-49 73-62 143-55 213c0 .3.2.7.5 1c32 23.6 63 38 93.6 47.3c.5 0 1 0 1.3-.4c7.2-9.8 13.6-20.2 19.2-31.2c.3-.6 0-1.4-.7-1.6c-10-4-20-8.6-29.3-14c-.7-.4-.8-1.5 0-2c2-1.5 4-3 5.8-4.5c.3-.3.8-.3 1.2-.2c61.4 28 128 28 188 0c.4-.2.9-.1 1.2.1c1.9 1.6 3.8 3.1 5.8 4.6c.7.5.6 1.6 0 2c-9.3 5.5-19 10-29.3 14c-.7.3-1 1-.6 1.7c5.6 11 12.1 21.3 19 31c.3.4.8.6 1.3.4c30.6-9.5 61.7-23.8 93.8-47.3c.3-.2.5-.5.5-1c7.8-80.9-13.1-151-55.4-213c0-.2-.3-.4-.5-.4Zm-192 171c-19 0-34-17-34-38c0-21 15-38 34-38c19 0 34 17 34 38c0 21-15 38-34 38zm125 0c-19 0-34-17-34-38c0-21 15-38 34-38c19 0 34 17 34 38c0 21-15 38-34 38z" />

--- a/themes/shovels/templates/header.html
+++ b/themes/shovels/templates/header.html
@@ -212,7 +212,7 @@
                 <p class="mt-1 text-sm text-emerald-800">All of our posts and announcements about building permit and contractor databases.</p>
               </div>
             </a>
-            <a href="https://support.shovels.ai" class="-m-3 flex items-start rounded-lg p-3 hover:bg-gray-50" target="_blank">
+            <a href="https://docs.shovels.ai/docs/knowledge-base" class="-m-3 flex items-start rounded-lg p-3 hover:bg-gray-50" target="_blank">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6 flex-shrink-0 text-slate-600">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
               </svg>
@@ -401,7 +401,7 @@ Leaving: "duration-100 ease-in"
     <div class="space-y-6 py-6 px-5">
       <div class="grid grid-cols-2 gap-y-4 gap-x-8">
         <a href="{{ SITEURL }}/about" class="text-base  text-emerald-900 hover:text-gray-700">Company</a>
-        <a href="https://support.shovels.ai" class="text-base  text-emerald-900 hover:text-gray-700">Support</a>
+        <a href="https://docs.shovels.ai/docs/knowledge-base" class="text-base  text-emerald-900 hover:text-gray-700">Knowledge Base</a>
         <a href="https://docs.shovels.ai" class="text-base  text-emerald-900 hover:text-gray-700">Documentation</a>
         <a href="{{ SITEURL }}/careers" class="text-base  text-emerald-900 hover:text-gray-700">Careers</a>
         <a href="{{ SITEURL }}/blog" class="text-base  text-emerald-900 hover:text-gray-700">Blog</a>

--- a/themes/shovels/templates/index.html
+++ b/themes/shovels/templates/index.html
@@ -255,7 +255,7 @@
                 {% endif %}
                 <div class="text-sm/6">
                   <p class="font-semibold text-gray-900">
-                    <a href="{{ SITEURL }}/author/{{ article.author.url }}">
+                    <a href="{{ SITEURL }}/{{ article.author.url }}">
                       <span class="absolute inset-0"></span>
                       {{ article.author }}
                     </a>


### PR DESCRIPTION
- Migrate support.shovels.ai links to docs.shovels.ai/docs/knowledge-base
- Update Discord URLs from discord.gg to discord.com/invite
- Fix author URL double path issue in index.html template
- Fix template syntax in markdown files (climate.md, about.md)
- Remove broken safari-pinned-tab.svg reference
- Replace dead Pipedrive scheduler links with /contact
- Replace dead Notion job posting links with /careers
- Remove defunct Google Play app links
- Update API tutorial references to docs.shovels.ai