### PR TITLE
Add structured data (JSON-LD) and robots.txt for SEO sitelinks

### DIFF
--- a/content/extras/robots.txt
+++ b/content/extras/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.shovels.ai/sitemap.xml

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -57,6 +57,7 @@ EXTRA_PATH_METADATA = {
     'extras/favicon.ico': {'path': 'favicon.ico'},
     'extras/favicon-16x16.png': {'path': 'favicon-16x16.png'},
     'extras/favicon-32x32.png': {'path': 'favicon-32x32.png'},
+    'extras/robots.txt': {'path': 'robots.txt'},
 }
 
 # Theme static files configuration

--- a/themes/shovels/templates/article.html
+++ b/themes/shovels/templates/article.html
@@ -30,6 +30,43 @@
 
 {% endblock %}
 
+{% block structured_data %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "{{ article.title|striptags|e }}",
+    "url": "{{ SITEURL }}/{{ article.url }}",
+    "datePublished": "{{ article.date.isoformat() }}",
+    {% if article.modified %}
+    "dateModified": "{{ article.modified.isoformat() }}",
+    {% else %}
+    "dateModified": "{{ article.date.isoformat() }}",
+    {% endif %}
+    "author": {
+      "@type": "Person",
+      "name": "{{ article.author }}"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Shovels",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.shovels.ai/theme/images/shovels-social.png"
+      }
+    },
+    {% if article.summary %}
+    "description": "{{ article.summary|striptags|truncate(160)|e }}",
+    {% endif %}
+    "image": "{% if article.image %}{{ SITEURL }}{{ article.image }}{% else %}https://www.shovels.ai/theme/images/shovels-social.png{% endif %}",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "{{ SITEURL }}/{{ article.url }}"
+    }
+  }
+  </script>
+{% endblock structured_data %}
+
 {% block content %}
 
 <div class="mx-auto max-w-[744px]">

--- a/themes/shovels/templates/base.html
+++ b/themes/shovels/templates/base.html
@@ -117,6 +117,83 @@
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+
+  <!-- Structured Data: Organization -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Shovels",
+    "url": "https://www.shovels.ai",
+    "logo": "https://www.shovels.ai/theme/images/shovels-social.png",
+    "description": "Shovels captures the first signal of construction—using AI to turn fragmented permit data into Shovel-ready intelligence.",
+    "sameAs": [
+      "https://twitter.com/shovelsai",
+      "https://www.linkedin.com/company/shovels-ai"
+    ]
+  }
+  </script>
+
+  <!-- Structured Data: WebSite -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Shovels",
+    "url": "https://www.shovels.ai"
+  }
+  </script>
+
+  <!-- Structured Data: SiteNavigationElement -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "SiteNavigationElement",
+        "name": "API",
+        "url": "https://www.shovels.ai/api"
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "name": "Permit Database",
+        "url": "https://www.shovels.ai/permit-database"
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "name": "Enterprise Data Feed",
+        "url": "https://www.shovels.ai/enterprise"
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "name": "GIS",
+        "url": "https://www.shovels.ai/gis"
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "name": "Blog",
+        "url": "https://www.shovels.ai/blog/"
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "name": "About",
+        "url": "https://www.shovels.ai/about"
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "name": "Careers",
+        "url": "https://www.shovels.ai/careers"
+      },
+      {
+        "@type": "SiteNavigationElement",
+        "name": "Contact Sales",
+        "url": "https://www.shovels.ai/contact-sales"
+      }
+    ]
+  }
+  </script>
+
+  {% block structured_data %}{% endblock structured_data %}
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- Added **Organization**, **WebSite**, and **SiteNavigationElement** JSON-LD structured data to `base.html` so Google can better understand the site hierarchy and generate sitelinks
- Added **Article** JSON-LD schema to `article.html` for rich blog post snippets in search results
- Created `robots.txt` pointing to the XML sitemap for improved crawl discovery

## Test plan
- [ ] Run `pelican -lr` and inspect page source on homepage — verify 3 JSON-LD blocks (Organization, WebSite, SiteNavigationElement)
- [ ] Inspect page source on a blog post — verify 4 JSON-LD blocks (the 3 above + Article)
- [ ] Verify `localhost:8000/robots.txt` loads with correct sitemap URL
- [ ] Validate structured data with [Google Rich Results Test](https://search.google.com/test/rich-results) after deploy