### PR TITLE
Add Senior Customer Success Manager job posting

### DIFF
--- a/content/pages/careers-senior-cs.md
+++ b/content/pages/careers-senior-cs.md
@@ -1,0 +1,127 @@
+Title: Senior Customer Success Manager
+Description: Join Shovels as a Senior Customer Success Manager to drive retention, expansion, and long-term customer value. Manage strategic enterprise accounts while building the operational backbone of our Support function.
+slug: careers/senior-cs
+
+<!-- back link -->
+<section class="py-6">
+  <div class="mx-auto max-w-4xl px-6">
+    <a href="{filename}careers.md" class="text-emerald-900 hover:underline">← Back to Careers</a>
+  </div>
+</section>
+
+<!-- position title -->
+<section class="my-12">
+  <div class="mx-auto max-w-4xl px-6">
+    <h1 class="text-3xl md:text-4xl font-bold tracking-tight mb-6">Senior Customer Success Manager</h1>
+    <p class="text-lg text-gray-600 mb-2">Full-time | Remote (West Coast preferred) | Customer Success & Growth</p>
+  </div>
+</section>
+
+<!-- intro section -->
+<section class="my-12 md:my-24">
+  <div class="mx-auto max-w-4xl px-6">
+    <p class="mb-4">Shovels is building the Google for local government data — collecting, cleaning, and making useful all of the public government data that is not publicly available. We transform messy building permit and contractor data into actionable, game-changing intelligence for the built world.</p>
+    <p class="mb-4">Backed by multi-million-dollar VC funding and trusted by some of the largest Fortune 100 companies in the world, we've found strong product-market fit and are scaling quickly.</p>
+    <p class="mb-4"><strong>Customer Success at Shovels is not a support function — it is a core growth engine.</strong> We're hiring a <strong>Senior Customer Success Manager</strong> to help drive retention, expansion, and long-term customer value as we scale.</p>
+    <p>If you're excited to operate at the center of a high-growth company and directly impact revenue — we'd love to talk.</p>
+  </div>
+</section>
+
+<!-- the role -->
+<section class="my-12 md:my-24">
+  <div class="mx-auto max-w-4xl px-6">
+    <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-6">The Role</h2>
+    <p class="mb-4">This is a hybrid strategic + operational role.</p>
+    <p class="mb-4">You will manage and grow a portfolio of strategic enterprise accounts while also serving as the operational backbone of our Support function — building the systems, processes, and knowledge infrastructure that allow Customer Success to scale.</p>
+    <p class="mb-4">You will be directly responsible for ensuring customers achieve measurable value from Shovels — driving adoption, retention, and expansion within your accounts — while also designing how we deliver high-quality, AI-enabled support at scale.</p>
+    <p>This is a high-impact, customer-facing role with meaningful revenue ownership and internal systems leadership.</p>
+  </div>
+</section>
+
+<!-- what you'll do -->
+<section class="my-12 md:my-24">
+  <div class="mx-auto max-w-4xl px-6">
+    <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-6">What You'll Do</h2>
+
+    <h3 class="text-xl font-bold mb-3 mt-6">Own and Grow Strategic Accounts</h3>
+    <ul class="list-disc pl-6 space-y-2 mb-6">
+      <li>Lead onboarding and implementation for new enterprise customers</li>
+      <li>Drive adoption and measurable business outcomes</li>
+      <li>Manage renewals and expansion within your portfolio, in concert with Sales</li>
+      <li>Lead QBRs and strategic account reviews</li>
+      <li>Build executive relationships</li>
+      <li>Act as the trusted advisor and primary point of contact</li>
+    </ul>
+
+    <h3 class="text-xl font-bold mb-3 mt-6">Build and Scale Support Operations</h3>
+    <ul class="list-disc pl-6 space-y-2">
+      <li>Own and manage the customer support ticket pipeline</li>
+      <li>Build, organize, and maintain a best-in-class knowledge base</li>
+      <li>Improve response quality, SLAs, and customer satisfaction</li>
+      <li>Design scalable processes for handling inbound support as we grow</li>
+      <li>Develop and optimize AI-powered workflows to enhance customer support and internal efficiency</li>
+      <li>Embrace and champion AI tools to build smarter systems across Customer Success</li>
+    </ul>
+  </div>
+</section>
+
+<!-- what we're looking for -->
+<section class="my-12 md:my-24">
+  <div class="mx-auto max-w-4xl px-6">
+    <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-6">What We're Looking For</h2>
+    <p class="mb-4">You are customer-obsessed, commercially minded, and comfortable owning revenue outcomes.</p>
+    <p class="mb-4">You likely have:</p>
+    <ul class="list-disc pl-6 space-y-2">
+      <li>4–8+ years in Customer Success, Account Management, or consulting within SaaS or data-driven businesses</li>
+      <li>Experience managing enterprise accounts</li>
+      <li>Demonstrated ownership of renewals and expansion</li>
+      <li>Strong executive communication skills</li>
+      <li>Ability to translate complex data products into clear business value</li>
+      <li>Proactive, structured, and highly accountable work style</li>
+      <li>Comfort operating in a fast-paced startup environment</li>
+      <li>Authorization to work in the U.S. (West Coast preferred)</li>
+    </ul>
+  </div>
+</section>
+
+<!-- why this role matters -->
+<section class="my-12 md:my-24">
+  <div class="mx-auto max-w-4xl px-6">
+    <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-6">Why This Role Matters</h2>
+    <p class="mb-4">Customer Success at Shovels is a core revenue driver — directly shaping retention, expansion, and long-term customer value.</p>
+    <p class="mb-4">You'll be a foundational pillar of the team at an important stage of growth. You'll help define how we scale Customer Success, influence cross-functional decisions across Sales, Data Insights, and Engineering, and build the systems that support our next phase of expansion.</p>
+    <p class="mb-4">This is an opportunity to join early and make an outsized impact. You'll work directly with some of the largest enterprises in the world, gaining a front-row seat into how they leverage Shovels' data to drive real business outcomes. Your work will directly shape your customers' growth and their long-term partnership with Shovels.</p>
+    <p>In doing so, you'll play a key role in defining our net revenue retention strategy and how Shovels scales as a company.</p>
+  </div>
+</section>
+
+<!-- why shovels -->
+<section class="my-12 md:my-24">
+  <div class="mx-auto max-w-4xl px-6">
+    <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-6">Why Shovels?</h2>
+    <ul class="list-disc pl-6 space-y-2">
+      <li><strong>Impact from day one:</strong> Your work will directly shape our product and company.</li>
+      <li><strong>Room to grow:</strong> Early team members will play leadership roles as the company expands.</li>
+      <li><strong>Flexibility:</strong> Fully remote, async-friendly culture with no strict 9-to-5 rules.</li>
+      <li><strong>Transparency:</strong> You'll see the inner workings of the business and help shape its future.</li>
+      <li><strong>Great pay + stock options:</strong> Competitive salary and meaningful equity in a company that's on the rise.</li>
+    </ul>
+  </div>
+</section>
+
+<!-- how we work -->
+<section class="my-12 md:my-24">
+  <div class="mx-auto max-w-4xl px-6">
+    <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-6">How We Work</h2>
+    <p>We're a small, fully-remote global team, so flexibility and communication are key. Our core hours overlap enough to make collaboration smooth, but we trust you to manage your time and prioritize your work. We stay connected via Slack, bi-weekly calls, with impromptu 1:1s when needed, and keep things casual and fun. Twice a year, we bring everyone together for in-person team summits to connect, strategize, and celebrate our progress.</p>
+  </div>
+</section>
+
+<!-- how to apply -->
+<section class="my-12 md:my-24">
+  <div class="mx-auto max-w-4xl px-6">
+    <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-6">Interested?</h2>
+    <p class="mb-4">Send your resume, LinkedIn profile, and a short note on why you're excited about Shovels and this role to:</p>
+    <p class="text-lg"><a href="mailto:betty@shovels.ai" class="text-blue-600 hover:underline font-bold">betty@shovels.ai</a></p>
+  </div>
+</section>

--- a/content/pages/careers.md
+++ b/content/pages/careers.md
@@ -66,6 +66,23 @@ slug: careers
           View Details →
         </a>
       </div>
+      <!-- senior customer success manager card -->
+      <div class="border border-gray-200 rounded-lg p-6 hover:shadow-lg transition-shadow">
+        <h3 class="text-2xl font-bold mb-3">Senior Customer Success Manager</h3>
+        <p class="text-gray-600 mb-4">Drive retention, expansion, and long-term customer value as we scale. Manage strategic enterprise accounts while building the operational backbone of our Support function.</p>
+        <div class="mb-4">
+          <p class="text-sm font-semibold text-gray-700 mb-2">Key highlights:</p>
+          <ul class="text-sm text-gray-600 space-y-1">
+            <li>• 4-8+ years in Customer Success or Account Management</li>
+            <li>• Manage enterprise accounts and drive revenue outcomes</li>
+            <li>• Build scalable support operations and AI-powered workflows</li>
+            <li>• Remote (West Coast preferred), competitive salary + equity</li>
+          </ul>
+        </div>
+        <a href="{filename}careers-senior-cs.md" class="inline-block bg-emerald-900 text-white px-6 py-2 rounded hover:bg-emerald-800 transition-colors">
+          View Details →
+        </a>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
Add new job posting for Senior Customer Success Manager role. Create dedicated careers page with full job details and add job card to the main careers landing page.

## Why are we making this change?
Shovels is hiring for a Senior CS Manager to manage strategic enterprise accounts and build scalable support operations. This posting makes the role publicly available on the careers site.