### PR TITLE
Support custom open graph images for pages

### DIFF
--- a/themes/shovels/templates/base.html
+++ b/themes/shovels/templates/base.html
@@ -89,7 +89,7 @@
     <meta property="og:description" content="Shovels captures the first signal of construction—using AI to turn fragmented permit data into Shovel-ready intelligence. Access via API, web app, or data warehouse." />
   {% endif %}
   {% block og_image %}
-  <meta property="og:image" content="{% if article and article.open_graph_image %}{{ SITEURL }}{{ article.open_graph_image }}{% elif article and article.image %}{{ SITEURL }}{{ article.image }}{% else %}{{ SITEURL }}/theme/images/shovels-social.png{% endif %}" />
+  <meta property="og:image" content="{% if page and page.open_graph_image %}{{ SITEURL }}{{ page.open_graph_image }}{% elif article and article.open_graph_image %}{{ SITEURL }}{{ article.open_graph_image }}{% elif page and page.image %}{{ SITEURL }}{{ page.image }}{% elif article and article.image %}{{ SITEURL }}{{ article.image }}{% else %}{{ SITEURL }}/theme/images/shovels-social.png{% endif %}" />
   <meta property="og:image:alt" content="{% if article %}{{ article.title|striptags }} - Shovels{% elif page %}{{ page.title|striptags }} - Shovels{% else %}Shovels - The intelligence layer for the built world{% endif %}" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -110,7 +110,7 @@
   {% else %}
     <meta name="twitter:description" content="Shovels captures the first signal of construction—using AI to turn fragmented permit data into Shovel-ready intelligence. Access via API, web app, or data warehouse." />
   {% endif %}
-  <meta name="twitter:image" content="{% if article and article.twitter_image %}{{ SITEURL }}{{ article.twitter_image }}{% elif article and article.open_graph_image %}{{ SITEURL }}{{ article.open_graph_image }}{% elif article and article.image %}{{ SITEURL }}{{ article.image }}{% else %}{{ SITEURL }}/theme/images/shovels-social.png{% endif %}" />
+  <meta name="twitter:image" content="{% if page and page.twitter_image %}{{ SITEURL }}{{ page.twitter_image }}{% elif article and article.twitter_image %}{{ SITEURL }}{{ article.twitter_image }}{% elif page and page.open_graph_image %}{{ SITEURL }}{{ page.open_graph_image }}{% elif article and article.open_graph_image %}{{ SITEURL }}{{ article.open_graph_image }}{% elif page and page.image %}{{ SITEURL }}{{ page.image }}{% elif article and article.image %}{{ SITEURL }}{{ article.image }}{% else %}{{ SITEURL }}/theme/images/shovels-social.png{% endif %}" />
   {% endblock head %}
 
   <!-- Favicons (low priority) -->


### PR DESCRIPTION
## Summary
- Fixes open graph and Twitter card images for pages (currently only worked for blog articles)
- Data dictionary page now displays its custom OG image on social media
- Enables custom social sharing images for any page or article via frontmatter

## Changes
Updated `base.html` template to check for custom images on both pages and articles with the following priority:
1. `twitter_image` field (Twitter card only)
2. `open_graph_image` field (custom OG image)
3. `image` field (generic image)
4. Default fallback: `/theme/images/shovels-social.png`

## Test plan
- [ ] Merge and deploy
- [ ] Test data dictionary page: https://www.shovels.ai/data-dictionary
- [ ] Validate OG image using [Facebook Debugger](https://developers.facebook.com/tools/debug/)
- [ ] Validate Twitter card using [Twitter Card Validator](https://cards-dev.twitter.com/validator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)