### PR TITLE
Hide coverage stats row on mobile

### DIFF
--- a/themes/shovels/templates/coverage.html
+++ b/themes/shovels/templates/coverage.html
@@ -154,7 +154,7 @@
 
 <!-- Summary stats (above treemap, single row) -->
 <div class="mx-auto max-w-7xl px-6 lg:px-8 pb-6">
-  <dl id="treemap-stats" class="flex justify-center gap-x-10 text-center">
+  <dl id="treemap-stats" class="hidden md:flex justify-center gap-x-10 text-center">
     <div>
       <dt class="text-sm text-gray-500">Total Permits</dt>
       <dd id="stat-total" class="text-2xl font-medium text-shovels-primary">—</dd>


### PR DESCRIPTION
## Summary
- Hide the five-column stats bar (`Total Permits`, `States Covered`, etc.) on mobile viewports where it doesn't fit
- Uses `hidden md:flex` so the stats only display on medium+ screens