### PR TITLE
Add CLI landing page at shovels.ai/cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-PY?=
-PELICAN?=pelican
+VENV=$(CURDIR)/.venv
+PY=$(VENV)/bin/python3
+PELICAN?=$(VENV)/bin/pelican
 PELICANOPTS=
 
 BASEDIR=$(CURDIR)
@@ -48,33 +49,38 @@ help:
 	@echo 'Set the RELATIVE variable to 1 to enable relative urls                    '
 	@echo '                                                                          '
 
-html:
+venv: $(VENV)/bin/pelican
+$(VENV)/bin/pelican:
+	uv venv $(VENV)
+	uv pip install -r requirements.txt
+
+html: venv
 	"$(PELICAN)" "$(INPUTDIR)" -o "$(OUTPUTDIR)" -s "$(CONFFILE)" $(PELICANOPTS)
-	python3 generate_404.py
+	$(PY) generate_404.py
 
 clean:
 	[ ! -d "$(OUTPUTDIR)" ] || rm -rf "$(OUTPUTDIR)"
 
-regenerate:
+regenerate: venv
 	"$(PELICAN)" -r "$(INPUTDIR)" -o "$(OUTPUTDIR)" -s "$(CONFFILE)" $(PELICANOPTS)
 
-serve:
+serve: venv
 	"$(PELICAN)" -l "$(INPUTDIR)" -o "$(OUTPUTDIR)" -s "$(CONFFILE)" $(PELICANOPTS)
 
-serve-global:
+serve-global: venv
 	"$(PELICAN)" -l "$(INPUTDIR)" -o "$(OUTPUTDIR)" -s "$(CONFFILE)" $(PELICANOPTS) -b $(SERVER)
 
-devserver:
+devserver: venv
 	npm run build:css & "$(PELICAN)" -lr "$(INPUTDIR)" -o "$(OUTPUTDIR)" -s "$(CONFFILE)" $(PELICANOPTS)
 
-devserver-global:
+devserver-global: venv
 	$(PELICAN) -lr $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -b 0.0.0.0
 
-publish:
+publish: venv
 	npm run build:css:prod
-	pelican content -o docs -s publishconf.py
+	"$(PELICAN)" content -o docs -s publishconf.py
 	cp themes/shovels/static/css/output.css docs/output.css
-	python3 generate_404.py
+	$(PY) generate_404.py
 	echo "www.shovels.ai" > docs/CNAME
 	git add .
 	git commit -am "publishing"
@@ -85,4 +91,4 @@ github: publish
 	git push origin $(GITHUB_PAGES_BRANCH)
 
 
-.PHONY: html help clean regenerate serve serve-global devserver publish github
+.PHONY: html help clean regenerate serve serve-global devserver publish github venv

--- a/content/extras/install.sh
+++ b/content/extras/install.sh
@@ -1,0 +1,213 @@
+#!/bin/sh
+# Shovels CLI installer
+# Usage: curl -LsSf https://shovels.ai/install.sh | sh
+#
+# Environment variables:
+#   SHOVELS_VERSION     Pin to a specific version (e.g. v0.1.0)
+#   SHOVELS_INSTALL_DIR Override install directory (default: ~/.shovels/bin)
+#   GITHUB_TOKEN        Required while repo is private; not needed once public
+set -eu
+
+REPO="ShovelsAI/shovels-cli"
+INSTALL_DIR="${SHOVELS_INSTALL_DIR:-$HOME/.shovels/bin}"
+
+# --- helpers ----------------------------------------------------------------
+
+say() { printf '%s\n' "$*"; }
+err() { say "Error: $*" >&2; exit 1; }
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || err "'$1' is required but not found"
+}
+
+# Authenticated curl — passes GITHUB_TOKEN if set
+fetch() {
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    curl -fsSL --retry 3 -H "Authorization: Bearer ${GITHUB_TOKEN}" "$@"
+  else
+    curl -fsSL --retry 3 "$@"
+  fi
+}
+
+# --- detect platform --------------------------------------------------------
+
+detect_os() {
+  case "$(uname -s)" in
+    Linux*)  echo "linux" ;;
+    Darwin*) echo "darwin" ;;
+    MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
+    *) err "Unsupported OS: $(uname -s)" ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)   echo "amd64" ;;
+    aarch64|arm64)   echo "arm64" ;;
+    *) err "Unsupported architecture: $(uname -m)" ;;
+  esac
+}
+
+# --- resolve latest version -------------------------------------------------
+
+latest_version() {
+  fetch "https://api.github.com/repos/${REPO}/releases/latest" |
+    grep '"tag_name"' | cut -d'"' -f4
+}
+
+# --- download release assets ------------------------------------------------
+
+# For private repos, github.com download URLs 404 even with a token.
+# We must use the API to find asset IDs, then download via the API.
+
+download_release_assets() {
+  RELEASE_TAG="$1"
+  shift
+  # remaining args are filename/dest pairs
+
+  if [ -z "${GITHUB_TOKEN:-}" ]; then
+    # Public repo: direct download
+    BASE="https://github.com/${REPO}/releases/download/${RELEASE_TAG}"
+    while [ $# -ge 2 ]; do
+      fetch "${BASE}/$1" -o "$2"
+      shift 2
+    done
+    return
+  fi
+
+  # Private repo: query API for asset list, download by ID
+  ASSETS_JSON=$(fetch "https://api.github.com/repos/${REPO}/releases/tags/${RELEASE_TAG}")
+
+  while [ $# -ge 2 ]; do
+    FILENAME="$1"
+    DEST="$2"
+    shift 2
+
+    ASSET_URL=$(printf '%s' "$ASSETS_JSON" | grep -B2 "\"name\": \"${FILENAME}\"" | grep '"url"' | cut -d'"' -f4)
+    if [ -z "$ASSET_URL" ]; then
+      err "Asset '${FILENAME}' not found in release ${RELEASE_TAG}"
+    fi
+    fetch -H "Accept: application/octet-stream" "${ASSET_URL}" -o "${DEST}"
+  done
+}
+
+# --- main -------------------------------------------------------------------
+
+main() {
+  need curl
+  need tar
+
+  OS=$(detect_os)
+  ARCH=$(detect_arch)
+
+  say "Resolving latest version..."
+  VERSION="${SHOVELS_VERSION:-$(latest_version)}"
+  if [ -z "$VERSION" ]; then
+    err "Could not determine latest version. If the repo is private, set GITHUB_TOKEN."
+  fi
+  VERSION_NUM="${VERSION#v}"  # strip leading v
+
+  say "Installing shovels ${VERSION} (${OS}/${ARCH})"
+
+  # Build archive name
+  if [ "$OS" = "windows" ]; then
+    ARCHIVE="shovels_${VERSION_NUM}_${OS}_${ARCH}.zip"
+  else
+    ARCHIVE="shovels_${VERSION_NUM}_${OS}_${ARCH}.tar.gz"
+  fi
+  BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+
+  # Download to temp dir
+  TEMP_DIR=$(mktemp -d)
+  trap 'rm -rf "$TEMP_DIR"' EXIT
+
+  say "Downloading ${ARCHIVE}..."
+  download_release_assets "${VERSION}" \
+    "${ARCHIVE}" "${TEMP_DIR}/${ARCHIVE}" \
+    "checksums.txt" "${TEMP_DIR}/checksums.txt"
+
+  # Verify checksum
+  say "Verifying checksum..."
+  EXPECTED=$(grep "${ARCHIVE}" "${TEMP_DIR}/checksums.txt" | cut -d' ' -f1)
+  if [ -z "$EXPECTED" ]; then
+    err "Archive not found in checksums.txt"
+  fi
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL=$(sha256sum "${TEMP_DIR}/${ARCHIVE}" | cut -d' ' -f1)
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL=$(shasum -a 256 "${TEMP_DIR}/${ARCHIVE}" | cut -d' ' -f1)
+  else
+    say "Warning: no sha256sum or shasum found, skipping verification"
+    ACTUAL="$EXPECTED"
+  fi
+
+  if [ "$EXPECTED" != "$ACTUAL" ]; then
+    err "Checksum mismatch: expected ${EXPECTED}, got ${ACTUAL}"
+  fi
+
+  # Extract
+  if [ "$OS" = "windows" ]; then
+    need unzip
+    unzip -qo "${TEMP_DIR}/${ARCHIVE}" -d "${TEMP_DIR}"
+  else
+    tar -xzf "${TEMP_DIR}/${ARCHIVE}" -C "${TEMP_DIR}"
+  fi
+
+  # Install
+  mkdir -p "${INSTALL_DIR}"
+  mv "${TEMP_DIR}/shovels" "${INSTALL_DIR}/shovels"
+  chmod +x "${INSTALL_DIR}/shovels"
+
+  say "Installed shovels to ${INSTALL_DIR}/shovels"
+
+  # Add to PATH if needed
+  add_to_path
+
+  say ""
+  say "Run 'shovels version' to verify."
+  say "Run 'shovels --help' to get started."
+}
+
+# --- PATH setup -------------------------------------------------------------
+
+add_to_path() {
+  # Already on PATH?
+  case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) return ;;
+  esac
+
+  SHELL_NAME=$(basename "${SHELL:-/bin/sh}")
+  PROFILE=""
+
+  case "$SHELL_NAME" in
+    zsh)  PROFILE="$HOME/.zshrc" ;;
+    bash)
+      if [ -f "$HOME/.bashrc" ]; then
+        PROFILE="$HOME/.bashrc"
+      else
+        PROFILE="$HOME/.bash_profile"
+      fi
+      ;;
+    fish)
+      FISH_DIR="$HOME/.config/fish/conf.d"
+      mkdir -p "$FISH_DIR"
+      if ! grep -q "shovels" "$FISH_DIR/shovels.fish" 2>/dev/null; then
+        printf 'set -gx PATH "%s" $PATH\n' "$INSTALL_DIR" > "$FISH_DIR/shovels.fish"
+        say "Added ${INSTALL_DIR} to PATH in ${FISH_DIR}/shovels.fish"
+      fi
+      return
+      ;;
+    *)    PROFILE="$HOME/.profile" ;;
+  esac
+
+  if [ -n "$PROFILE" ]; then
+    if ! grep -q "/.shovels/bin" "$PROFILE" 2>/dev/null; then
+      printf '\n# Shovels CLI\nexport PATH="%s:$PATH"\n' "$INSTALL_DIR" >> "$PROFILE"
+      say "Added ${INSTALL_DIR} to PATH in ${PROFILE}"
+      say "Restart your shell or run: source ${PROFILE}"
+    fi
+  fi
+}
+
+main "$@"

--- a/content/pages/cli.md
+++ b/content/pages/cli.md
@@ -1,0 +1,408 @@
+Title: Shovels CLI — Construction data from your terminal
+Description: Agent-first CLI for the Shovels building permit and contractor API. One binary. JSON output. Zero interactivity. Built for AI agents, scripts, and developers who live in the terminal.
+slug: cli
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<!-- HERO                                                                   -->
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+
+<svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <defs>
+    <pattern id="cli-grid" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
+      <path d="M100 200V.5M.5 .5H200" fill="none" />
+    </pattern>
+  </defs>
+  <rect width="100%" height="100%" stroke-width="0" fill="url(#cli-grid)" />
+</svg>
+
+<div class="relative isolate overflow-hidden">
+  <div class="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
+    <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-none lg:grid lg:grid-cols-2 lg:gap-x-16 lg:gap-y-6">
+      <div>
+        <h1 class="max-w-xl text-balance text-5xl font-semibold tracking-tight text-gray-900 sm:text-7xl">Construction data from your terminal</h1>
+        <p class="mt-6 max-w-xl text-pretty text-lg font-medium text-gray-500 sm:text-xl/8">Your AI agent's gateway to U.S. construction data.</p>
+        <div class="mt-10 flex items-center gap-x-6">
+          <a href="https://app.shovels.ai/" class="rounded-md bg-shovels-primary px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-shovels-primary/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-shovels-primary">Get your API key</a>
+          <a href="https://github.com/ShovelsAI/shovels-cli" class="text-sm/6 font-semibold text-gray-900">View on GitHub <span aria-hidden="true">&rarr;</span></a>
+        </div>
+      </div>
+      <!-- Terminal mockup -->
+      <div class="mt-10 lg:mt-0">
+        <div class="rounded-xl bg-gray-900 shadow-2xl ring-1 ring-white/10 overflow-hidden">
+          <div class="flex items-center gap-2 px-4 py-3 border-b border-white/10">
+            <span class="size-3 rounded-full bg-red-500"></span>
+            <span class="size-3 rounded-full bg-yellow-500"></span>
+            <span class="size-3 rounded-full bg-green-500"></span>
+            <span class="ml-2 text-sm text-gray-400 font-mono">terminal</span>
+          </div>
+          <div class="p-5 font-mono text-sm leading-relaxed">
+            <p class="text-gray-400">$ <span class="text-white">curl -LsSf https://shovels.ai/install.sh | sh</span></p>
+            <p class="text-green-400 mt-1">Installed shovels to ~/.shovels/bin/shovels</p>
+            <p class="text-gray-500 mt-4"># How many solar permits in 92024 (Encinitas, CA) last year?</p>
+            <p class="text-gray-400 mt-1">$ <span class="text-white">shovels permits search --geo-id 92024 \</span></p>
+            <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-from 2024-01-01 --permit-to 2024-12-31 \</p>
+            <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--tags solar --include-count --limit 1 \</p>
+            <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;| jq '.meta.total_count.value'</p>
+            <p class="text-shovels-secondary mt-1">581</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="absolute inset-x-0 bottom-0 -z-10 h-24 bg-gradient-to-t from-white sm:h-32"></div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<!-- WHAT CAN YOU DO — Command showcase                                     -->
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+
+<div class="bg-gray-900 py-24 sm:py-32">
+  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+    <div class="mx-auto max-w-2xl sm:text-center">
+      <p class="text-base/7 font-semibold text-shovels-secondary">Permits, contractors, addresses</p>
+      <h2 class="mt-2 text-pretty text-4xl font-semibold tracking-tight text-white sm:text-balance sm:text-5xl">Everything in one binary</h2>
+      <p class="mt-6 text-lg/8 text-gray-300">No SDKs, no dependencies, no configuration files. Download a single binary and start querying construction data in seconds.</p>
+    </div>
+  </div>
+
+  <!-- Command examples grid -->
+  <div class="mx-auto mt-16 max-w-7xl px-6 lg:px-8">
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+
+      <!-- Example 1: Search permits -->
+      <div class="rounded-xl bg-gray-800/50 ring-1 ring-white/10 overflow-hidden">
+        <div class="px-5 py-3 border-b border-white/10">
+          <p class="text-sm font-semibold text-shovels-secondary">Roofing permits in Miami Beach</p>
+        </div>
+        <div class="p-5 font-mono text-sm leading-relaxed">
+          <p class="text-gray-400">$ <span class="text-white">shovels permits search \</span></p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--geo-id 33139 \ <span class="text-gray-500"># Miami Beach, FL</span></p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-from 2024-01-01 \</p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-to 2024-12-31 \</p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--tags roofing --include-count</p>
+        </div>
+      </div>
+
+      <!-- Example 2: Get contractor details -->
+      <div class="rounded-xl bg-gray-800/50 ring-1 ring-white/10 overflow-hidden">
+        <div class="px-5 py-3 border-b border-white/10">
+          <p class="text-sm font-semibold text-shovels-secondary">How many permits has this contractor filed?</p>
+        </div>
+        <div class="p-5 font-mono text-sm leading-relaxed">
+          <p class="text-gray-400">$ <span class="text-white">shovels contractors permits 03xTGkafsf</span> <span class="text-gray-500"># Cosmic Solar Inc.</span></p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--limit all \</p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;| jq '.data | length'</p>
+          <p class="text-shovels-secondary mt-1">2056</p>
+        </div>
+      </div>
+
+      <!-- Example 3: Pipeline -->
+      <div class="rounded-xl bg-gray-800/50 ring-1 ring-white/10 overflow-hidden">
+        <div class="px-5 py-3 border-b border-white/10">
+          <p class="text-sm font-semibold text-shovels-secondary">Export electrical contractors to CSV</p>
+        </div>
+        <div class="p-5 font-mono text-sm leading-relaxed">
+          <p class="text-gray-400">$ <span class="text-white">shovels contractors search \</span></p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--geo-id 78701 \ <span class="text-gray-500"># Austin, TX</span></p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-from 2024-01-01 \</p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-to 2024-12-31 \</p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--tags electrical --limit 100 \</p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;| jq -r '.data[] | [.name, .total_permits] | @csv'</p>
+        </div>
+      </div>
+
+      <!-- Example 4: Address lookup -->
+      <div class="rounded-xl bg-gray-800/50 ring-1 ring-white/10 overflow-hidden">
+        <div class="px-5 py-3 border-b border-white/10">
+          <p class="text-sm font-semibold text-shovels-secondary">Resolve an address to a geo_id</p>
+        </div>
+        <div class="p-5 font-mono text-sm leading-relaxed">
+          <p class="text-gray-400">$ <span class="text-white">shovels addresses search \</span></p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;-q "1600 Pennsylvania Ave" \</p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;| jq '.data[0] | {name, geo_id}'</p>
+          <p class="text-gray-300 mt-1">{</p>
+          <p class="text-gray-300">&nbsp;&nbsp;"name": "<span class="text-green-400">1600 Pennsylvania Ave Nw, Washington, DC</span>",</p>
+          <p class="text-gray-300">&nbsp;&nbsp;"geo_id": "<span class="text-shovels-secondary">Kw5MGExoU6Y</span>"</p>
+          <p class="text-gray-300">}</p>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<!-- BUILT FOR AI AGENTS                                                    -->
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+
+<div class="bg-white py-24 sm:py-32">
+  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+    <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-none lg:grid lg:grid-cols-2 lg:gap-x-16 lg:items-start">
+      <div>
+        <p class="text-base/7 font-semibold text-shovels-secondary">Agent-first design</p>
+        <h2 class="mt-2 text-pretty text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">Your AI agent's interface to construction data</h2>
+        <p class="mt-6 text-lg/8 text-gray-600">No MCP headaches — no context bloat, no credential juggling, no host lock-in. Claude Code, OpenAI Codex, Cursor, or your own agents shell out to <code class="text-sm bg-gray-100 px-1.5 py-0.5 rounded">shovels</code> and get structured data back instantly.</p>
+        <dl class="mt-10 max-w-xl space-y-6 text-base/7 text-gray-600">
+          <div class="relative pl-9">
+            <dt class="font-semibold text-gray-900">
+              <svg class="absolute left-0 top-1 size-5 text-shovels-secondary" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" /></svg>
+              JSON to stdout. Always.
+            </dt>
+            <dd class="mt-1">No tables, no colors, no spinners. stdout is always valid JSON. Errors go to stderr. Your parser never breaks.</dd>
+          </div>
+          <div class="relative pl-9">
+            <dt class="font-semibold text-gray-900">
+              <svg class="absolute left-0 top-1 size-5 text-shovels-secondary" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" /></svg>
+              Help text written for LLMs
+            </dt>
+            <dd class="mt-1">Every <code class="text-sm bg-gray-100 px-1.5 py-0.5 rounded">--help</code> is specific, example-rich, and jargon-free. An AI agent can read the help and construct the right command on the first try.</dd>
+          </div>
+          <div class="relative pl-9">
+            <dt class="font-semibold text-gray-900">
+              <svg class="absolute left-0 top-1 size-5 text-shovels-secondary" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" /></svg>
+              Meaningful exit codes
+            </dt>
+            <dd class="mt-1">Exit 0 = success. Exit 2 = auth error. Exit 3 = rate limited. Your agent can branch on the exit code without parsing anything.</dd>
+          </div>
+          <div class="relative pl-9">
+            <dt class="font-semibold text-gray-900">
+              <svg class="absolute left-0 top-1 size-5 text-shovels-secondary" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" /></svg>
+              Zero interactivity
+            </dt>
+            <dd class="mt-1">No prompts, no confirmations, no progress bars. It succeeds and prints JSON, or it fails and prints a JSON error. Nothing in between.</dd>
+          </div>
+        </dl>
+      </div>
+      <!-- AI agent terminal mockup -->
+      <div class="mt-10 lg:mt-0">
+        <div class="rounded-xl bg-gray-900 shadow-2xl ring-1 ring-white/10 overflow-hidden">
+          <div class="flex items-center gap-2 px-4 py-3 border-b border-white/10">
+            <span class="size-3 rounded-full bg-red-500"></span>
+            <span class="size-3 rounded-full bg-yellow-500"></span>
+            <span class="size-3 rounded-full bg-green-500"></span>
+            <span class="ml-2 text-sm text-gray-400 font-mono">claude code</span>
+          </div>
+          <div class="p-5 font-mono text-sm leading-relaxed">
+            <p class="text-gray-500 italic"># Your AI agent runs this:</p>
+            <p class="text-gray-400 mt-2">$ <span class="text-white">shovels permits search --help</span></p>
+            <p class="text-gray-400 mt-1">...</p>
+            <p class="text-gray-500 mt-3 italic"># Reads the help, builds the query:</p>
+            <p class="text-gray-400 mt-2">$ <span class="text-white">shovels permits search \</span></p>
+            <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--geo-id 94110 \ <span class="text-gray-500"># San Francisco, CA</span></p>
+            <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-from 2024-06-01 \</p>
+            <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-to 2024-12-31 \</p>
+            <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--tags roofing \</p>
+            <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--property-type residential \</p>
+            <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--limit 20</p>
+            <p class="text-gray-500 mt-3 italic"># Parses the JSON, reasons about the results,</p>
+            <p class="text-gray-500 italic"># then asks for contractor details...</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<!-- COMPOSABILITY — Pipe it, chain it, script it                           -->
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+
+<div class="bg-gray-50 py-24 sm:py-32">
+  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+    <div class="mx-auto max-w-2xl sm:text-center">
+      <p class="text-base/7 font-semibold text-shovels-secondary">Unix philosophy</p>
+      <h2 class="mt-2 text-pretty text-4xl font-semibold tracking-tight text-gray-900 sm:text-balance sm:text-5xl">Pipe it. Chain it. Script it.</h2>
+      <p class="mt-6 text-lg/8 text-gray-600">JSON output means you can compose the CLI with any tool in your stack. Build workflows that would take weeks with a GUI.</p>
+    </div>
+
+    <div class="mx-auto mt-16 max-w-4xl">
+      <div class="space-y-6">
+
+        <!-- Composability example 1 -->
+        <div class="rounded-xl bg-white shadow-sm ring-1 ring-gray-200 overflow-hidden">
+          <div class="px-5 py-3 border-b border-gray-100">
+            <p class="text-sm font-semibold text-gray-900">Build a solar contractor CSV in one line</p>
+          </div>
+          <div class="p-5 font-mono text-sm leading-relaxed bg-gray-900 text-white">
+            <p>shovels contractors search --geo-id CA \</p>
+            <p>&nbsp;&nbsp;--permit-from 2024-01-01 --permit-to 2024-12-31 \</p>
+            <p>&nbsp;&nbsp;--tags solar --limit all \</p>
+            <p>&nbsp;&nbsp;| jq -r '.data[] | [.name, .phone, .total_permits] | @csv' \</p>
+            <p>&nbsp;&nbsp;> solar_contractors_ca.csv</p>
+          </div>
+        </div>
+
+        <!-- Composability example 2 -->
+        <div class="rounded-xl bg-white shadow-sm ring-1 ring-gray-200 overflow-hidden">
+          <div class="px-5 py-3 border-b border-gray-100">
+            <p class="text-sm font-semibold text-gray-900">Monitor new permits in your market (cron job)</p>
+          </div>
+          <div class="p-5 font-mono text-sm leading-relaxed bg-gray-900 text-white">
+            <p><span class="text-gray-500"># crontab: 0 8 * * MON</span></p>
+            <p>shovels permits search --geo-id 94110 \ <span class="text-gray-500"># San Francisco, CA</span></p>
+            <p>&nbsp;&nbsp;--permit-from $(date -v-7d +%Y-%m-%d) \</p>
+            <p>&nbsp;&nbsp;--permit-to $(date +%Y-%m-%d) \</p>
+            <p>&nbsp;&nbsp;| jq '.meta.count' \</p>
+            <p>&nbsp;&nbsp;| xargs -I{} echo "{} new permits this week in 94110"</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<!-- WHY NOT JUST CURL — The comparison                                     -->
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+
+<div class="bg-white py-24 sm:py-32">
+  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+    <div class="mx-auto max-w-2xl sm:text-center">
+      <p class="text-base/7 font-semibold text-shovels-secondary">Why not just curl?</p>
+      <h2 class="mt-2 text-pretty text-4xl font-semibold tracking-tight text-gray-900 sm:text-balance sm:text-5xl">Because pagination shouldn't be your problem</h2>
+    </div>
+
+    <div class="mx-auto mt-16 max-w-5xl grid grid-cols-1 gap-8 lg:grid-cols-2">
+
+      <!-- curl way -->
+      <div class="rounded-xl overflow-hidden ring-1 ring-red-200">
+        <div class="px-5 py-3 bg-red-50 border-b border-red-200">
+          <p class="text-sm font-semibold text-red-800">With curl: 15+ lines, manual pagination</p>
+        </div>
+        <div class="p-5 font-mono text-xs leading-relaxed bg-gray-900 text-gray-300">
+          <p>cursor=""</p>
+          <p>while true; do</p>
+          <p>&nbsp;&nbsp;resp=$(curl -s -H "X-API-Key: $KEY" \</p>
+          <p>&nbsp;&nbsp;&nbsp;&nbsp;"https://api.shovels.ai/v2/permits/search\</p>
+          <p>&nbsp;&nbsp;&nbsp;&nbsp;?geo_id=92024&permit_from=2024-01-01\</p>
+          <p>&nbsp;&nbsp;&nbsp;&nbsp;&permit_to=2024-12-31&cursor=$cursor")</p>
+          <p>&nbsp;&nbsp;echo "$resp" | jq '.items[]'</p>
+          <p>&nbsp;&nbsp;cursor=$(echo "$resp" | jq -r '.next_cursor')</p>
+          <p>&nbsp;&nbsp;[ "$cursor" = "null" ] && break</p>
+          <p>done</p>
+        </div>
+      </div>
+
+      <!-- CLI way -->
+      <div class="rounded-xl overflow-hidden ring-1 ring-green-200">
+        <div class="px-5 py-3 bg-green-50 border-b border-green-200">
+          <p class="text-sm font-semibold text-green-800">With shovels: one command, all records</p>
+        </div>
+        <div class="p-5 font-mono text-sm leading-relaxed bg-gray-900 text-white">
+          <p>shovels permits search \</p>
+          <p>&nbsp;&nbsp;--geo-id 92024 \</p>
+          <p>&nbsp;&nbsp;--permit-from 2024-01-01 \</p>
+          <p>&nbsp;&nbsp;--permit-to 2024-12-31 \</p>
+          <p>&nbsp;&nbsp;--limit all</p>
+        </div>
+      </div>
+
+    </div>
+    <p class="mx-auto mt-8 max-w-xl text-center text-base text-gray-500">The CLI handles auth headers, cursor pagination, rate-limit retries, and credit tracking. You just say how many records you want.</p>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<!-- FEATURE GRID                                                           -->
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+
+<div class="bg-gray-900 py-24 sm:py-32">
+  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+    <dl class="mx-auto grid max-w-2xl grid-cols-1 gap-x-6 gap-y-10 text-base/7 text-gray-300 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3 lg:gap-x-8 lg:gap-y-16">
+      <div class="relative pl-9">
+        <dt class="inline font-semibold text-white">
+          <svg class="absolute left-1 top-1 size-5 text-shovels-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z" /></svg>
+          Single binary.
+        </dt>
+        <dd class="inline">No runtime, no dependencies. Download one file, put it on your PATH, done. macOS, Linux, and Windows.</dd>
+      </div>
+      <div class="relative pl-9">
+        <dt class="inline font-semibold text-white">
+          <svg class="absolute left-1 top-1 size-5 text-shovels-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25H12" /></svg>
+          Pagination handled.
+        </dt>
+        <dd class="inline"><code class="text-xs bg-white/10 px-1 rounded">--limit all</code> fetches every record. The CLI manages cursors, page sizes, and the 100K ceiling internally.</dd>
+      </div>
+      <div class="relative pl-9">
+        <dt class="inline font-semibold text-white">
+          <svg class="absolute left-1 top-1 size-5 text-shovels-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182" /></svg>
+          Auto-retry.
+        </dt>
+        <dd class="inline">Rate-limited? The CLI backs off with jitter and retries automatically. Respects Retry-After headers.</dd>
+      </div>
+      <div class="relative pl-9">
+        <dt class="inline font-semibold text-white">
+          <svg class="absolute left-1 top-1 size-5 text-shovels-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+          Credit tracking.
+        </dt>
+        <dd class="inline">Every response includes <code class="text-xs bg-white/10 px-1 rounded">credits_used</code> and <code class="text-xs bg-white/10 px-1 rounded">credits_remaining</code>. Your agent always knows the cost.</dd>
+      </div>
+      <div class="relative pl-9">
+        <dt class="inline font-semibold text-white">
+          <svg class="absolute left-1 top-1 size-5 text-shovels-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" /></svg>
+          Checksum-verified installs.
+        </dt>
+        <dd class="inline">The install script downloads from GitHub Releases and verifies SHA256 checksums before touching your system.</dd>
+      </div>
+      <div class="relative pl-9">
+        <dt class="inline font-semibold text-white">
+          <svg class="absolute left-1 top-1 size-5 text-shovels-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5" /></svg>
+          Open source.
+        </dt>
+        <dd class="inline">MIT licensed. Read the code, fork it, contribute. Built with Go and Cobra.</dd>
+      </div>
+    </dl>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+<!-- INSTALL CTA                                                            -->
+<!-- ═══════════════════════════════════════════════════════════════════════ -->
+
+<div class="bg-gray-100">
+  <div class="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
+    <div class="mx-auto max-w-2xl sm:text-center">
+      <h2 class="text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">Get started in 10 seconds</h2>
+      <div class="mt-8 rounded-xl bg-gray-900 p-5 shadow-2xl ring-1 ring-white/10">
+        <p class="font-mono text-sm text-white text-center">curl -LsSf https://shovels.ai/install.sh | sh</p>
+      </div>
+      <p class="mt-6 text-base text-gray-600">Then set your API key and start querying:</p>
+      <div class="mt-4 rounded-xl bg-gray-900 p-5 shadow-2xl ring-1 ring-white/10">
+        <div class="font-mono text-sm text-left">
+          <p class="text-gray-400">$ <span class="text-white">export SHOVELS_API_KEY=your-key</span></p>
+          <p class="text-gray-400 mt-1">$ <span class="text-white">shovels permits search --geo-id 92024 --permit-from 2024-01-01 --permit-to 2024-12-31</span></p>
+        </div>
+      </div>
+      <div class="mt-10 flex items-center justify-center gap-x-6">
+        <a href="https://app.shovels.ai/" class="rounded-md bg-shovels-primary px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-shovels-primary/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-shovels-primary">Get your API key</a>
+        <a href="https://github.com/ShovelsAI/shovels-cli" class="text-sm/6 font-semibold text-gray-900">GitHub <span aria-hidden="true">&rarr;</span></a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- JSON-LD structured data for AI answer engines -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Shovels CLI",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "macOS, Linux, Windows",
+  "description": "Agent-first command-line interface for the Shovels building permit and contractor API. JSON-only output, automatic pagination, and structured error codes designed for AI agents and scripts.",
+  "url": "https://www.shovels.ai/cli",
+  "downloadUrl": "https://github.com/ShovelsAI/shovels-cli/releases/latest",
+  "softwareVersion": "0.1.0",
+  "license": "https://opensource.org/licenses/MIT",
+  "offers": {
+    "@type": "Offer",
+    "url": "https://app.shovels.ai/"
+  },
+  "author": {
+    "@type": "Organization",
+    "name": "Shovels",
+    "url": "https://www.shovels.ai"
+  }
+}
+</script>

--- a/content/pages/cli.md
+++ b/content/pages/cli.md
@@ -79,7 +79,9 @@ slug: cli
           <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--geo-id 33139 \ <span class="text-gray-500"># Miami Beach, FL</span></p>
           <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-from 2024-01-01 \</p>
           <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-to 2024-12-31 \</p>
-          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--tags roofing --include-count</p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--tags roofing --include-count \</p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--limit 1 | jq '.meta.total_count.value'</p>
+          <p class="text-shovels-secondary mt-1">490</p>
         </div>
       </div>
 
@@ -107,7 +109,11 @@ slug: cli
           <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-from 2024-01-01 \</p>
           <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--permit-to 2024-12-31 \</p>
           <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;--tags electrical --limit 100 \</p>
-          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;| jq -r '.data[] | [.name, .total_permits] | @csv'</p>
+          <p class="text-white">&nbsp;&nbsp;&nbsp;&nbsp;| jq -r '.data[] | [.name, .permit_count] | @csv'</p>
+          <p class="text-gray-300 mt-1">"KENNETH TUMLINSON",554</p>
+          <p class="text-gray-300">"JOSEPH H MARTINEZ",85</p>
+          <p class="text-gray-300">"CDX ELECTRICAL SERVICES",19</p>
+          <p class="text-gray-500">...</p>
         </div>
       </div>
 
@@ -227,7 +233,7 @@ slug: cli
             <p>shovels contractors search --geo-id CA \</p>
             <p>&nbsp;&nbsp;--permit-from 2024-01-01 --permit-to 2024-12-31 \</p>
             <p>&nbsp;&nbsp;--tags solar --limit all \</p>
-            <p>&nbsp;&nbsp;| jq -r '.data[] | [.name, .phone, .total_permits] | @csv' \</p>
+            <p>&nbsp;&nbsp;| jq -r '.data[] | [.name, .phone, .permit_count] | @csv' \</p>
             <p>&nbsp;&nbsp;> solar_contractors_ca.csv</p>
           </div>
         </div>

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -58,6 +58,7 @@ EXTRA_PATH_METADATA = {
     'extras/favicon-16x16.png': {'path': 'favicon-16x16.png'},
     'extras/favicon-32x32.png': {'path': 'favicon-32x32.png'},
     'extras/robots.txt': {'path': 'robots.txt'},
+    'extras/install.sh': {'path': 'install.sh'},
 }
 
 # Theme static files configuration

--- a/themes/shovels/templates/footer.html
+++ b/themes/shovels/templates/footer.html
@@ -35,6 +35,7 @@
         <ul x-show="solutionsOpen" x-transition role="list" class="pb-4 space-y-3">
           <li><a href="{{ SITEURL }}/data-feed" class="text-sm leading-6 hover:text-amber-500">Enterprise</a></li>
           <li><a href="{{ SITEURL }}/api" class="text-sm leading-6 hover:text-amber-500">API</a></li>
+          <li><a href="{{ SITEURL }}/cli" class="text-sm leading-6 hover:text-amber-500">CLI</a></li>
           <li><a href="{{ SITEURL }}/permit-database" class="text-sm leading-6 hover:text-amber-500">Online</a></li>
           <li><a href="{{ SITEURL }}/gis" class="text-sm leading-6 hover:text-amber-500">GIS</a></li>
           <li><a href="{{ SITEURL }}/audiences" class="text-sm leading-6 hover:text-amber-500">Audiences</a></li>
@@ -114,6 +115,9 @@
               </li>
               <li>
                 <a href="{{ SITEURL }}/api" class="text-sm leading-6 hover:text-amber-500">API</a>
+              </li>
+              <li>
+                <a href="{{ SITEURL }}/cli" class="text-sm leading-6 hover:text-amber-500">CLI</a>
               </li>
               <li>
                 <a href="{{ SITEURL }}/permit-database" class="text-sm leading-6 hover:text-amber-500">Online</a>

--- a/themes/shovels/templates/header.html
+++ b/themes/shovels/templates/header.html
@@ -133,10 +133,19 @@
                 <p class="mt-1 text-sm text-emerald-800">Access Shovels programmatically by looking up data by address or contractor name.</p>
               </div>
             </a>
+            <a href="{{ SITEURL }}/cli" class="-m-3 flex items-start rounded-lg p-3 hover:bg-gray-50">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6 flex-shrink-0 text-slate-600">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z" />
+              </svg>
+              <div class="ml-4">
+                <p class="text-base  text-emerald-900">CLI</p>
+                <p class="mt-1 text-sm text-emerald-800">Agent-first command-line tool. One binary, JSON output, zero interactivity.</p>
+              </div>
+            </a>
             <a href="{{ SITEURL }}/permit-database" class="-m-3 flex items-start rounded-lg p-3 hover:bg-gray-50">
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6 flex-shrink-0 text-slate-600">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25" />
-              </svg>              
+              </svg>
               <div class="ml-4">
                 <p class="text-base  text-emerald-900">Web App</p>
                 <p class="mt-1 text-sm text-emerald-800">Explore and download Shovels data from your desktop and mobile devices.</p>
@@ -370,6 +379,7 @@
       <div x-show="solutionsOpen" x-transition class="pb-4">
         <a href="{{ SITEURL }}/data-feed" class="block py-2 pl-4 text-sm text-gray-600 hover:text-emerald-800">Enterprise</a>
         <a href="{{ SITEURL }}/api" class="block py-2 pl-4 text-sm text-gray-600 hover:text-emerald-800">API</a>
+        <a href="{{ SITEURL }}/cli" class="block py-2 pl-4 text-sm text-gray-600 hover:text-emerald-800">CLI</a>
         <a href="{{ SITEURL }}/permit-database" class="block py-2 pl-4 text-sm text-gray-600 hover:text-emerald-800">Web App</a>
         <a href="{{ SITEURL }}/gis" class="block py-2 pl-4 text-sm text-gray-600 hover:text-emerald-800">GIS</a>
         <a href="{{ SITEURL }}/audiences" class="block py-2 pl-4 text-sm text-gray-600 hover:text-emerald-800">Audiences</a>


### PR DESCRIPTION
## Summary

- New `/cli` marketing page with 7 sections: hero terminal mockup, command showcase, agent-first positioning, composability examples, curl vs CLI comparison, feature grid, and install CTA
- Host `install.sh` at `shovels.ai/install.sh` — one-liner install: `curl -LsSf https://shovels.ai/install.sh | sh`
- Add CLI link to Solutions dropdown in site header (desktop + mobile)
- Fix Makefile to auto-create `.venv` via `uv` so `make devserver` works without a global pelican install

## Why

The Shovels CLI is now public at [github.com/ShovelsAI/shovels-cli](https://github.com/ShovelsAI/shovels-cli) with v0.1.0 released. It needs a marketing page that communicates the agent-first positioning — why a CLI instead of an MCP server, what makes it composable, and how to get started in 10 seconds. All examples are verified against the live API with real data.

Ref: ENG-1889