### PR TITLE
Fix author image path case sensitivity

### DIFF
--- a/content/posts/tampa-housing-market-permit-data.md
+++ b/content/posts/tampa-housing-market-permit-data.md
@@ -6,7 +6,7 @@ category: Data
 tags: Tampa, housing market, building permits, Florida, real estate, new construction, Hillsborough County, Manatee County, market forecast
 authors: Ruoji Tang
 author_image: /theme/images/team/Ruoji.svg
-author_title: Content Strategist
+author_title: Senior Marketing Manager
 slug: tampa-housing-market-permit-data
 summary: Our deep dive into Tampa building permits breaks down where construction is growing, where it's pulling back, and what it means for buyers, sellers, and builders.
 image: /images/blog_images/tampa-housing-market-permit-data-hero.png

--- a/content/posts/tampa-housing-market-permit-data.md
+++ b/content/posts/tampa-housing-market-permit-data.md
@@ -5,7 +5,7 @@ modified: 2026-03-13
 category: Data
 tags: Tampa, housing market, building permits, Florida, real estate, new construction, Hillsborough County, Manatee County, market forecast
 authors: Ruoji Tang
-author_image: /theme/images/team/ruoji.svg
+author_image: /theme/images/team/Ruoji.svg
 author_title: Content Strategist
 slug: tampa-housing-market-permit-data
 summary: Our deep dive into Tampa building permits breaks down where construction is growing, where it's pulling back, and what it means for buyers, sellers, and builders.


### PR DESCRIPTION
Fixes the author image not appearing on the Tampa blog post.

**Issue:** The file is named  (capital R) but frontmatter referenced  (lowercase). This works on macOS (case-insensitive) but fails on Linux servers (case-sensitive).

**Fix:** Update  to use correct case: 