### PR TITLE
Configure shovels-claude-plugins marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "shovels-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "ShovelsAI/shovels-claude-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "shovels-claude-plugins@revenue": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` pointing to the `ShovelsAI/shovels-claude-plugins` GitHub marketplace
- Enables the `revenue` plugin, which provides the `publish-blog` skill for the Notion-to-Pelican publishing workflow
- Removes the need to copy skill files into this repo manually

## Test plan

- [ ] Confirm `/publish-blog` is available after merging and reloading Claude Code in this repo