### PR TITLE
Add scroll hysteresis to sticky header

### DIFF
--- a/themes/shovels/templates/header.html
+++ b/themes/shovels/templates/header.html
@@ -1,5 +1,5 @@
 <div x-data="{ mobileOpen: false, scrolled: false }"
-     x-init="window.addEventListener('scroll', () => { scrolled = window.scrollY > 10 })"
+     x-init="window.addEventListener('scroll', () => { if (!scrolled && window.scrollY > 50) scrolled = true; else if (scrolled && window.scrollY <= 5) scrolled = false; })"
      x-effect="document.body.style.overflow = mobileOpen ? 'hidden' : ''"
      class="sticky top-0 z-50 transition-all duration-300"
      :class="scrolled ? 'bg-white/95 backdrop-blur-sm shadow-lg' : 'bg-transparent'">


### PR DESCRIPTION
## Summary
- Add scroll hysteresis to prevent header flicker on small scroll movements
- Activate sticky header at 50px (up from 10px), deactivate at 5px
- Separate thresholds eliminate rapid state toggling near the boundary

Closes ENG-2059
