### PR TITLE
Remove duplicate static height classes from navbar logo

### DIFF
--- a/themes/shovels/templates/header.html
+++ b/themes/shovels/templates/header.html
@@ -10,7 +10,7 @@
       <span class="sr-only">Shovels</span>
       <a class="no-underline hover:no-underline transform transition hover:scale-105 duration-300 ease-in-out mt-0" href="/">
         <img id="navbar-logo" src="{{ SITEURL }}/theme/images/shovels-navbar-logo.svg" alt="Shovels - Building permit and contractor intelligence"
-             class="h-8 w-auto sm:h-10 lg:h-12 transition-all duration-300"
+             class="w-auto transition-all duration-300"
              :class="scrolled ? 'h-6 sm:h-8' : 'h-8 sm:h-10 lg:h-12'" />
       </a>
     </a>


### PR DESCRIPTION
## Summary
The navbar logo had height classes (h-8, sm:h-10, lg:h-12) hardcoded in
the static `class` attribute while the same values appeared in the Alpine
`:class` binding's unscrolled state. The static copy persists regardless
of scroll state, leaving conflicting classes on the element when Alpine
toggles the dynamic binding.

Remove the height classes from the static attribute so the `:class`
binding has sole control over logo sizing.

This bug was identified during review of #98.