### PR TITLE
Update stale v1 API reference links to v2

### DIFF
--- a/content/posts/api-guide-1.md
+++ b/content/posts/api-guide-1.md
@@ -37,7 +37,7 @@ We offer 33 unique tags as of this publication date in October 2023. That number
 
 To use tags, you need to know what they are. We named them to (hopefully) be self-explanatory. If you need clarification, you can check the Tags tab in the [Data Dictionary]({filename}../pages/data-dictionary.md) . We'll try to keep this updated. 
 
-To see a list programmatically, perhaps for your own internal dashboard or BI tool, you can always list our tags using the [Get All Available Tags](https://docs.shovels.ai/api-reference/#operation/List/operation/get_all_available_tags_v1_list_tags_get){:target="_blank"}  endpoint.
+To see a list programmatically, perhaps for your own internal dashboard or BI tool, you can always list our tags using the [Get All Available Tags](https://docs.shovels.ai/api-reference/lists/get-all-available-tags){:target="_blank"}  endpoint.
 
 To make this extra super clear, let's go through some examples. I'm going to show the code snippets using Curl, a command-line tool available natively in every operating system. Just open a new command-line prompt (e.g. Terminal on MacOS) to use it. 
 
@@ -45,7 +45,7 @@ To make this extra super clear, let's go through some examples. I'm going to sho
 
 Let's use 94123, my old neighborhood in San Francisco. Start by finding the right tag (using the methodology above) for heat pumps: `heat_pump` should do the trick!
 
-Next, find the endpoint. [Get Permits By Zip Code](https://docs.shovels.ai/api-reference/#operation/Permits/operation/get_permits_by_zip_code_v1_permits_zip_get){:target="_blank"}  sounds about right! 
+Next, find the endpoint. [Get Permits By Zip Code](https://docs.shovels.ai/api-reference/permits/search-permits){:target="_blank"}  sounds about right! 
 
 Make the request. Here's the Curl command.
 
@@ -89,7 +89,7 @@ And it worked!
 }
 ```
 
-So what do we do with all those `id` values? Each one is an internal ID for a Shovels permit. To get the details we want (since we probably want more than just the address) let's take the `id` and pass it into our [Get Permit by ID](https://docs.shovels.ai/api-reference/#operation/Permits/operation/get_permit_by_id_v1_permits__id__get){:target="_blank"}  endpoint.
+So what do we do with all those `id` values? Each one is an internal ID for a Shovels permit. To get the details we want (since we probably want more than just the address) let's take the `id` and pass it into our [Get Permit by ID](https://docs.shovels.ai/api-reference/permits/get-permits-by-id){:target="_blank"}  endpoint.
 
 ```bash
 curl -X 'GET' \
@@ -137,7 +137,7 @@ Neato! If we wanted to store all these heat pump installs in a database or sprea
 
 What if you don't care about the permits or the homes, and you just want to know who did the install? We can help with that, too! 
 
-Our handy [Get Permits By Activity Zip Code](https://docs.shovels.ai/api-reference/#operation/Contractors/operation/get_contractors_by_activity_zipcode_v1_contractors_activity_zip_get){:target="_blank"}  endpoint should be perfect. We can use the same example, and we'll introduce dates this time. 
+Our handy [Get Permits By Activity Zip Code](https://docs.shovels.ai/api-reference/contractors/search-contractors){:target="_blank"}  endpoint should be perfect. We can use the same example, and we'll introduce dates this time. 
 
 For this API call, let's find all the heat pump HVAC installers who did work in the first two quarters of 2023. 
 
@@ -160,7 +160,7 @@ The response now is:
 }
 ```
 
-Same deal. The `id` shown is our internal Shovels contractor ID. Let's hit our [Get Contractor by Id](https://docs.shovels.ai/api-reference/#operation/Contractors/operation/get_contractor_by_id_v1_contractors__id__get){:target="_blank"}  endpoint with it to get those contractor details! 
+Same deal. The `id` shown is our internal Shovels contractor ID. Let's hit our [Get Contractor by Id](https://docs.shovels.ai/api-reference/contractors/get-contractors-by-id){:target="_blank"}  endpoint with it to get those contractor details! 
 
 ```
 curl -X 'GET' \
@@ -192,7 +192,7 @@ Building permits have dates galore. We show file dates, issue dates, and final d
 
 Our date filters, called `start_date` and `end_date`, are based solely on the file date.
 
-To show how this works, let's look at permits filed in New York in August 2023. We can use our [Get Permits by State](https://docs.shovels.ai/api-reference/#operation/Permits/operation/get_permits_by_state_v1_permits_state_get){:target="_blank"}  endpoint! 
+To show how this works, let's look at permits filed in New York in August 2023. We can use our [Get Permits by State](https://docs.shovels.ai/api-reference/permits/search-permits){:target="_blank"}  endpoint! 
 
 ```
 curl -X 'GET' \

--- a/content/posts/newsletter-dec-23.md
+++ b/content/posts/newsletter-dec-23.md
@@ -30,7 +30,7 @@ Yelp et al, therefore, won't recommend the best electrician working in your neig
 
 **But we do!**
 
-Here's the [API endpoint](https://docs.shovels.ai/api-reference/#operation/Contractors/operation/get_contractors_by_activity_zipcode_v1_contractors_activity_zip_get) to find the most active heat pump (etc, etc) contractor that works in your ZIP code. We'll add a basic interface to the Shovels app to show you this too. Or if you want a sample CSV report, just reply. 
+Here's the [API endpoint](https://docs.shovels.ai/api-reference/contractors/search-contractors) to find the most active heat pump (etc, etc) contractor that works in your ZIP code. We'll add a basic interface to the Shovels app to show you this too. Or if you want a sample CSV report, just reply. 
 
 Heat pumps galore ☀️
 ====================

--- a/content/posts/newsletter-feb-24.md
+++ b/content/posts/newsletter-feb-24.md
@@ -24,7 +24,7 @@ The case for software
 
 Shovels is a data company. That's our DNA. We're not very proficient (yet) at building software. We'll develop that skill as we go, but what will always set us apart is our devotion to clean, reliable, and useful data.
 
-We launched our nationwide [building permit API](https://docs.shovels.ai/api-reference/#operation/Permits) in August 2023. We followed that release with a [nationwide contractor API](https://docs.shovels.ai/api-reference/#operation/Contractors) in November 2023. We now have a bunch of paying customers and meaningful revenue. 
+We launched our nationwide [building permit API](https://docs.shovels.ai/api-reference/permits/search-permits) in August 2023. We followed that release with a [nationwide contractor API](https://docs.shovels.ai/api-reference/contractors/search-contractors) in November 2023. We now have a bunch of paying customers and meaningful revenue. 
 
 Just getting this far is a big deal! And we'll continue to serve our current and new API customers. We ❤️ API deals.
 

--- a/content/posts/newsletter-july-24.md
+++ b/content/posts/newsletter-july-24.md
@@ -70,7 +70,7 @@ From the Engineering desk
 Here are a few of the engineering tasks we finished last month. 
 
 *   **AI Permit tagging**: Our new AI-enhanced tagging process is now active in the data pipeline, processing 120 million permits so far. This upgrade allows us to classify new permits more swiftly and efficiently, utilizing the latest AI methods to deliver industry-leading results.
-*   **Enhanced address search**: We introduced a new [address search API endpoint](https://docs.shovels.ai/api-reference/#operation/search_addresses_v1_addresses_search_get). It is designed to simplify free-form address search for our customers and provide normalized addresses that can be used in other API calls supporting address parameters. This update aims to improve the user experience when using our API.
+*   **Enhanced address search**: We introduced a new [address search API endpoint](https://docs.shovels.ai/api-reference/addresses/search-addresses). It is designed to simplify free-form address search for our customers and provide normalized addresses that can be used in other API calls supporting address parameters. This update aims to improve the user experience when using our API.
 *   **Advanced contractor data handling**: Our contractor's dataset constantly evolves with new data and advanced data engineering techniques. To enable seamless customer integration, we now provide a full changelog detailing all changes from one month to the next.
 
 Things to do with permits: make a coverage heat map

--- a/content/posts/newsletter-june-24.md
+++ b/content/posts/newsletter-june-24.md
@@ -17,7 +17,7 @@ This month we started rebuilding a few things. The results are exciting!
 
 *   We rebuilt and re-released our web application. You can check it out now at [https://app.shovels.ai](https://app.shovels.ai). It just kinda needed to happen.
 *   We rebuilt our [API docs](https://docs.shovels.ai/api-reference/) too. 
-*   Speaking of API, we added city to the [permit search API](https://docs.shovels.ai/api-reference/#operation/search_permits_description_v1_permits_search_get) and the [contractor search API](https://docs.shovels.ai/api-reference/#operation/get_contractors_by_activity_city_v1_contractors_activity_city_get) (and the [new app](https://app.shovels.ai) and our [ShovelsGPT](https://chatgpt.com/g/g-zXFhOF8SP-shovels-ai)). 
+*   Speaking of API, we added city to the [permit search API](https://docs.shovels.ai/api-reference/permits/search-permits) and the [contractor search API](https://docs.shovels.ai/api-reference/contractors/search-contractors) (and the [new app](https://app.shovels.ai) and our [ShovelsGPT](https://chatgpt.com/g/g-zXFhOF8SP-shovels-ai)). 
 *   You can now also search contractors by their license classification  ⚡️
 *   We re-classified every building permit in Texas and the results are amazing. More details and the math behind this is below. The rest of the country is next.
 *   2 million more permits and 1.3 million new geo-tagged addresses. We also added 19 new jurisdictions. 

--- a/content/posts/newsletter-mar-24.md
+++ b/content/posts/newsletter-mar-24.md
@@ -73,7 +73,7 @@ It's a new month, and with that, a bunch of new fixes. Here's our March release 
 *   **Improvements in contractor grouping**: We're using more comprehensive details, including addresses and phone numbers, to cluster contractor branches into groups.
 *   **A new address dataset**: We added over three million exact geo locations to our permits table. We are closing down the gap of unlinked permits (permits without geo coordinates).
 *   **Improvements in our internal docs**: We move fast but we also recognize that investing in good documentation now will save us headaches later. We created a new internal knowledge base.
-*   **API enhancements**: We introduced a [new API call](https://docs.shovels.ai/api-reference/#operation/Permits/operation/get_permits_by_id_v1_permits_get) that allows for the specification of multiple permits in a single request.
+*   **API enhancements**: We introduced a [new API call](https://docs.shovels.ai/api-reference/permits/get-permits-by-id) that allows for the specification of multiple permits in a single request.
 *   **Database optimization**: In response to API usage patterns, we've restructured our database architecture. No more timeouts!
 *   **API monitoring**: We have integrated with an awesome tool to help us track API usage, errors, and patterns.
 

--- a/content/posts/newsletter-oct-23.md
+++ b/content/posts/newsletter-oct-23.md
@@ -42,9 +42,9 @@ Here's my attempt at writing the shortest-ever tutorial on how to use an API. We
 
 An API is like a set of defined questions you can ask a database using your favorite programming language. Each of these questions is called an "endpoint." 
 
-For example, you can ask [this endpoint](https://docs.shovels.ai/api-reference/#operation/Permits/operation/get_permits_by_address_v1_permits_address_get) the question, "What are all the permits on 15 Cherry Lane, Anytown, MD?"
+For example, you can ask [this endpoint](https://docs.shovels.ai/api-reference/permits/search-permits) the question, "What are all the permits on 15 Cherry Lane, Anytown, MD?"
 
-You can ask [this endpoint](https://docs.shovels.ai/api-reference/#operation/Permits/operation/get_permits_by_zip_code_v1_permits_zip_get) the question, "Which homes in the zip code 94123 pulled ADU permits in the last 6 months?"
+You can ask [this endpoint](https://docs.shovels.ai/api-reference/permits/search-permits) the question, "Which homes in the zip code 94123 pulled ADU permits in the last 6 months?"
 
 And so on... each endpoint is purpose-built for you to ask a certain type of question. The questions our endpoints can answer are described in our [lovely API documentation](https://docs.shovels.ai/api-reference). 
 

--- a/content/posts/newsletter-sep-23.md
+++ b/content/posts/newsletter-sep-23.md
@@ -17,7 +17,7 @@ I feel proud today. The Shovels team, all three of us, had a very productive two
 
 *   **🚀 We processed 100M building permits! We can run custom SQL queries and export CSV files for residential and commercial buildings nationwide. 🚀**
 *   States currently available in the API: California, Texas, Florida, and New York. Now that the rest are processed, we'll begin loading them into the API too. 
-*   Speaking of API, we released our [markets endpoint](https://docs.shovels.ai/api-reference/#operation/Markets/operation/get_market_activity_by_zip_code_v1_markets_permits_zip_get). We count current and historical building permit counts on all of our zip codes sliced by any of our tags. I'll describe an interesting application for this data below! 
+*   Speaking of API, we released our [markets endpoint](https://docs.shovels.ai/api-reference/addresses/get-address-metrics-current). We count current and historical building permit counts on all of our zip codes sliced by any of our tags. I'll describe an interesting application for this data below! 
 *   We also released [new prettier API docs](https://docs.shovels.ai/api-reference). Why does this matter? I'll tell you.
 *   Our pricing matrix is good to go. You'll know what cost to expect when you're ready to get on this building permit data bandwagon. 
 

--- a/content/posts/shovels-101-address-permit-history.md
+++ b/content/posts/shovels-101-address-permit-history.md
@@ -30,7 +30,7 @@ With the Shovels API, you can get from address to detailed permit history based 
 
 ## Step 1: Finding the Address
 
-Using the [GET Search Addresses](https://docs.shovels.ai/api-reference/#operation/search_addresses_v1_addresses_search_get)  endpoint, search for the address to confirm that there are any permits on record (our system goes back ~20 years). 
+Using the [GET Search Addresses](https://docs.shovels.ai/api-reference/addresses/search-addresses)  endpoint, search for the address to confirm that there are any permits on record (our system goes back ~20 years). 
 
 A sample query, for a “123 Main St”, should look something like this:
 
@@ -98,7 +98,7 @@ Pick which address you want to dig deeper into, and **proceed to step 2**.
 
 Using the data returned in Step 1, we will now retrieve the exact permits themselves for the desired address. 
 
-Using the [GET Permits by Address](https://docs.shovels.ai/api-reference/#operation/get_permits_by_address_v1_permits_address_get) endpoint, enter the relevant address data to the next query. The list of required parameters are noted in the schema on the API doc linked just above. 
+Using the [GET Permits by Address](https://docs.shovels.ai/api-reference/permits/search-permits) endpoint, enter the relevant address data to the next query. The list of required parameters are noted in the schema on the API doc linked just above. 
 
 Again, a sample query, for “123 Main St, Agawam, MA 01001”, would look something like this:
 
@@ -133,7 +133,7 @@ To do so, **proceed to Step 3**.
 
 ## Step 3: Return Detailed Permit History
 
-Using the [GET Permits by ID](https://docs.shovels.ai/api-reference/#operation/get_permits_by_id_v1_permits_get) endpoint, you can search for a single (or string array) of permit IDs. 
+Using the [GET Permits by ID](https://docs.shovels.ai/api-reference/permits/get-permits-by-id) endpoint, you can search for a single (or string array) of permit IDs. 
 
 In this sample, to request the first permit payload would look something like this:
 
@@ -188,7 +188,7 @@ For enterprise-level usage, get our full dataset with deeper insights, dashboard
 
 ## Troubleshooting Tips
 
-- A full list of our error codes are described in our API docs [here](https://docs.shovels.ai/api-reference/#section/API-Details). Most errors are 404s, which frequently mean either the address is input incorrectly, or there isn’t a permit record on file to match the search terms.
+- A full list of our error codes are described in our API docs [here](https://docs.shovels.ai/api-reference). Most errors are 404s, which frequently mean either the address is input incorrectly, or there isn’t a permit record on file to match the search terms.
     - If you are able to find the correct address in our **Web App**, then double check the syntax of the request. 
 - If you run into any other questions, please email us at [support@shovels.ai](mailto:support@shovels.ai) and we’ll help you!
 


### PR DESCRIPTION
## Summary
- Replace 19 stale v1 API reference URLs across 9 blog posts with v2 equivalents
- V1 links used `#operation/...` fragment URLs that no longer resolve to specific endpoints on the v2 docs site
- All v2 replacement URLs verified returning 200 on live docs.shovels.ai

## V1 → V2 mapping
| V1 pattern | V2 page |
|---|---|
| Permits by zip/address/state | `/api-reference/permits/search-permits` |
| Permits by ID | `/api-reference/permits/get-permits-by-id` |
| Contractors by zip/city | `/api-reference/contractors/search-contractors` |
| Contractor by ID | `/api-reference/contractors/get-contractors-by-id` |
| Markets by zip | `/api-reference/addresses/get-address-metrics-current` |
| Address search | `/api-reference/addresses/search-addresses` |
| Tags list | `/api-reference/lists/get-all-available-tags` |

## Files changed
- `api-guide-1.md` (6 links)
- `shovels-101-address-permit-history.md` (4 links)
- `newsletter-oct-23.md` (2 links)
- `newsletter-sep-23.md`, `newsletter-dec-23.md`, `newsletter-feb-24.md`, `newsletter-june-24.md`, `newsletter-july-24.md`, `newsletter-mar-24.md` (1-2 links each)

## Test plan
- [x] All 8 unique v2 URLs verified with `curl` returning 200 on live docs.shovels.ai
- [x] `grep` confirms zero remaining `#operation` links in `content/`