### PR TITLE
Add structured Tag1/Tag2 taxonomy and fix blog categories

### DIFF
--- a/content/posts/2024-recap.md
+++ b/content/posts/2024-recap.md
@@ -3,6 +3,8 @@ Date: 2025-01-13
 Subtitle: Quick summary of what we've been up to in 2024
 Modified: 2025-01-13
 Category: Company
+Tag1:
+Tag2:
 Tags: 2024
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/5g-beyond-urban-centers-permit-data.md
+++ b/content/posts/5g-beyond-urban-centers-permit-data.md
@@ -3,6 +3,8 @@ subtitle: People are migrating away from urban centers, but is 5G keeping up?
 date: 2026-03-13
 modified: 2026-03-13
 category: Data
+tag1:
+tag2: Telecommunications
 tags: Telecommunications, Housing Growth, Building Permits, Broadband Coverage, Real Estate Trends, 5G
 authors: Ruoji Tang
 author_image: /theme/images/team/Ruoji.svg

--- a/content/posts/address-permit-history.md
+++ b/content/posts/address-permit-history.md
@@ -3,6 +3,8 @@ Subtitle: Understand the nuance of why a given address would have a permit on re
 Date: 2024-10-02
 Modified: 2024-10-02
 Category: Customer Success
+Tag1: Construction Permits 101
+Tag2:
 Tags: permits, tutorial, resource, address
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/adu-2025.md
+++ b/content/posts/adu-2025.md
@@ -3,6 +3,8 @@ subtitle: A data-driven look at how ADUs are reshaping housing supply, what poli
 date: 2025-10-27
 modified: 2025-10-27
 category: Data
+tag1: ADU Content
+tag2:
 tags: ADU, Accessory Dwelling Unit, Housing Crisis, Housing Policy, Building Permits, Data Analysis, Urban Development, Housing Affordability, State Housing Laws
 authors: Morgan Friberg
 author_image: /theme/images/team/morgan.svg

--- a/content/posts/ahj.md
+++ b/content/posts/ahj.md
@@ -3,6 +3,8 @@ Subtitle: A practical guide to understanding AHJ, permits, and jurisdiction chal
 Date: 2025-09-15
 Modified: 2025-09-15
 Category: Customer Success
+Tag1: Construction Permits 101
+Tag2:
 Tags: AHJ in construction, AHJ permitting, Authority Having Jurisdiction, construction permits
 Authors: Morgan Friberg
 Author_image: /theme/images/team/morgan.svg

--- a/content/posts/ai-classifications.md
+++ b/content/posts/ai-classifications.md
@@ -3,6 +3,8 @@ Subtitle: Revolutionizing contractor data with AI-powered classifications and co
 Date: 2025-06-04
 Modified: 2025-06-04
 Category: Company
+Tag1:
+Tag2:
 Tags: ai-classification, contractor-licensing, data-processing, machine-learning, permit-categories
 Authors: Betty Wan
 Author_image: /theme/images/team/betty.svg

--- a/content/posts/analysis-texas-roofing-income.md
+++ b/content/posts/analysis-texas-roofing-income.md
@@ -3,6 +3,8 @@ Subtitle: A deep dive into the relationship between household income levels and 
 Date: 2025-01-23
 Modified: 2025-01-23
 Category: Data
+Tag1:
+Tag2: Home Services
 Tags: texas, roofing permits, analysis
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/api-guide-1.md
+++ b/content/posts/api-guide-1.md
@@ -3,6 +3,8 @@ Subtitle: The definitive guide to getting started with the Shovels V1 API
 Date: 2023-10-13
 Modified: 2023-10-13
 Category: Customer Success
+Tag1: API
+Tag2:
 Tags: api
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/api-guide-2.md
+++ b/content/posts/api-guide-2.md
@@ -3,6 +3,8 @@ Subtitle: The definitive guide to getting started with the Shovels V2 API
 Date: 2024-12-26
 Modified: 2024-12-26
 Category: Customer Success
+Tag1: API
+Tag2:
 Tags: api
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/app-guide-1.md
+++ b/content/posts/app-guide-1.md
@@ -3,6 +3,8 @@ Subtitle: The definitive guide to getting started with the Shovels app
 Date: 2024-02-12
 Modified: 2023-02-12
 Category: Customer Success
+Tag1: Shovels Online
+Tag2:
 Tags: app, launch
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/autodesk.md
+++ b/content/posts/autodesk.md
@@ -3,6 +3,8 @@ Subtitle: Get permit data in Autodesk Construction Cloud
 Date: 2024-8-9
 Modified: 2024-8-9
 Category: Company
+Tag1:
+Tag2: Construction Technology
 Tags: construction software, autodesk construction cloud,
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/bayren-affiliations.md
+++ b/content/posts/bayren-affiliations.md
@@ -3,6 +3,8 @@ Subtitle: We find that affiliations with rebate programs have an impact on speci
 Date: 2023-11-19
 Modified: 2023-11-10
 Category: Data
+Tag1: Solar & EV
+Tag2: Energy & Climate
 Tags: bayren, rebates, climate
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/bzail-spotlight.md
+++ b/content/posts/bzail-spotlight.md
@@ -3,6 +3,8 @@ Subtitle: Learn how BAIZEL is leveraging Shovels' permit data to revolutionize c
 Date: 2025-07-18
 Modified: 2025-07-18
 Category: Case Study
+Tag1:
+Tag2: Real Estate
 Tags: spotlight, integration, API, BAIZEL, site selection, commercial real estate
 Authors: Betty Wan
 Author_image: /theme/images/team/betty.svg

--- a/content/posts/case-61hawk.md
+++ b/content/posts/case-61hawk.md
@@ -3,6 +3,8 @@ Subtitle: How 61HAWK used Charlie and Shovels permit intelligence to uncover hun
 Date: 2026-01-28
 Modified: 2026-01-28
 Category: Case Study
+Tag1: Charlie
+Tag2:
 Tags: case, customer, charlie
 Authors: Morgan Friberg
 Author_image: /theme/images/team/morgan.svg

--- a/content/posts/case-beam.md
+++ b/content/posts/case-beam.md
@@ -3,6 +3,8 @@ Subtitle: Shovels: The ultimate lead generation solution for Beam and other cons
 Date: 2024-4-8
 Modified: 2024-4-8
 Category: Case Study
+Tag1: Lead Generation
+Tag2: Home Services
 Tags: case,customer
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/case-boldr.md
+++ b/content/posts/case-boldr.md
@@ -3,6 +3,8 @@ Subtitle: Transforming HVAC Market Intelligence with Data-Driven Permit Insights
 Date: 2025-08-11
 Modified: 2025-08-11
 Category: Case Study
+Tag1: Lead Generation
+Tag2: Home Services
 Tags: spotlight,case,customer,boldr
 Authors: Betty Wan
 Author_image: /theme/images/team/betty.svg

--- a/content/posts/case-carbon-free-homes.md
+++ b/content/posts/case-carbon-free-homes.md
@@ -3,6 +3,8 @@ Subtitle: Shovels Empowers Carbon Free Homes, Achieving 100% Installation Target
 Date: 2024-5-13
 Modified: 2024-5-13
 Category: Case Study
+Tag1:
+Tag2: Energy & Climate
 Tags: case,customer
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/case-copper.md
+++ b/content/posts/case-copper.md
@@ -3,6 +3,8 @@ Subtitle: How a Berkeley startup used permit data to identify 4,036 electrificat
 Date: 2025-08-12
 Modified: 2025-08-12
 Category: Case Study
+Tag1: Solar & EV
+Tag2: Energy & Climate
 Tags: spotlight, case study, customer, copper
 Authors: Betty Wan
 Author_image: /theme/images/team/betty.svg

--- a/content/posts/contech-gtm.md
+++ b/content/posts/contech-gtm.md
@@ -2,7 +2,9 @@ Title: Go-to-market strategies for contech companies
 Subtitle: Use building permits to create an effective go-to-market plan for construction technology (contech) companies
 Date: 2023-7-10
 Modified: 2023-7-10
-Category: GTM
+Category: Customer Success
+Tag1: Lead Generation
+Tag2: Construction Technology
 Tags: gtm, building permits
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/csl-release.md
+++ b/content/posts/csl-release.md
@@ -3,6 +3,8 @@ Subtitle: Introducing our nationwide contractor licensing dataset with standardi
 Date: 2025-05-30
 Modified: 2025-05-30
 Category: Company
+Tag1: EDL
+Tag2:
 Tags: data, contractors, product, integration
 Authors: Betty Wan
 Author_image: /theme/images/team/betty.svg

--- a/content/posts/cw-2025-hackathon.md
+++ b/content/posts/cw-2025-hackathon.md
@@ -3,6 +3,8 @@ Subtitle: A recap of the San Francisco Climate Week Hackathon held on April 22, 
 Date: 2025-04-22
 Modified: 2025-04-22
 Category: Company
+Tag1:
+Tag2: Energy & Climate
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/digging-in-1-solar-trends.md
+++ b/content/posts/digging-in-1-solar-trends.md
@@ -3,6 +3,8 @@ Subtitle: Insights into US Solar Construction Trends using the Shovels platform 
 Date: 2024-09-11
 Modified: 2024-09-11
 Category: Data
+Tag1: Solar & EV
+Tag2: Energy & Climate
 Tags: RE Plus, Solar, Insights
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/esri-hosted-feature.md
+++ b/content/posts/esri-hosted-feature.md
@@ -4,6 +4,8 @@ Slug: arcgis-permit-insights
 Date: 2025-09-17
 Modified: 2025-09-17
 Category: Company
+Tag1:
+Tag2:
 Tags: ArcGIS, GIS, Permits, Predictive Analytics, Utilities, Real Estate, Telecommunications, Data Integration, Construction, AI
 Authors: Morgan Friberg
 Author_image: /theme/images/team/morgan.svg

--- a/content/posts/esri-living-atlas.md
+++ b/content/posts/esri-living-atlas.md
@@ -3,6 +3,8 @@ Subtitle: Our permit data is now accessible to millions of GIS professionals thr
 Date: 2026-01-08
 Modified: 2026-01-08
 Category: Company
+Tag1:
+Tag2:
 Tags: Esri, Living Atlas, GIS, building permits, partnerships, ArcGIS
 Authors: Morgan Friberg
 Author_image: /theme/images/team/morgan.svg

--- a/content/posts/ev-charger-contractors.md
+++ b/content/posts/ev-charger-contractors.md
@@ -3,6 +3,8 @@ Subtitle: As demand for EV chargers grows, so does the need for more contractors
 Date: 2023-10-1
 Modified: 2023-10-1
 Category: Data
+Tag1: Solar & EV
+Tag2: Energy & Climate
 Tags: gtm, building contractors, ev chargers, climate
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/ev-charger-growth.md
+++ b/content/posts/ev-charger-growth.md
@@ -3,6 +3,8 @@ Subtitle: California's EV charging infrastructure is experiencing unprecedented 
 Date: 2023-7-24
 Modified: 2023-7-24
 Category: Data
+Tag1: Solar & EV
+Tag2: Energy & Climate
 Tags: gtm, building permits, ev chargers, climate
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/ev-permit-approvals.md
+++ b/content/posts/ev-permit-approvals.md
@@ -3,6 +3,8 @@ Subtitle: There's a wide disparity in the time it takes for EV charger permits t
 Date: 2023-8-10
 Modified: 2023-8-10
 Category: Data
+Tag1: Solar & EV
+Tag2: Energy & Climate
 Tags: gtm, building permits, ev chargers, permit timeline, climate
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/florida-housing-market-2026.md
+++ b/content/posts/florida-housing-market-2026.md
@@ -3,6 +3,8 @@ subtitle: We look at construction-side indicators including new construction per
 date: 2026-02-25
 modified: 2026-02-25
 category: Data
+tag1: Florida Housing
+tag2: Real Estate
 tags: Florida housing market, building permit data, data analysis, ADUs, solar panels, Florida housing market crash, florida hurricane preparedness, lennar homes florida, net metering florida, adu florida
 authors: Ruoji Tang
 author_image: /theme/images/team/Ruoji.svg

--- a/content/posts/gpt-guide-1.md
+++ b/content/posts/gpt-guide-1.md
@@ -3,6 +3,8 @@ Subtitle: Get started accessing Shovels data within ChatGPT
 Date: 2024-4-24
 Modified: 2024-4-13
 Category: Customer Success
+Tag1:
+Tag2:
 Tags: ai, chatgpt, openai
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/harvest-season.md
+++ b/content/posts/harvest-season.md
@@ -3,6 +3,8 @@ Subtitle: How Shovels combines data streams to improve their product
 Date: 2024-10-17
 Modified: 2024-10-17
 Category: Company
+Tag1:
+Tag2:
 Tags: data enrichment, API integration, new release 
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/how-to-find-construction-leads-shovels.md
+++ b/content/posts/how-to-find-construction-leads-shovels.md
@@ -3,6 +3,8 @@ Subtitle: An end-to-end guide to contractor lead generation using Shovels
 Date: 2026-03-03
 Modified: 2026-03-03
 Category: Customer Success
+Tag1: Lead Generation
+Tag2: Building Materials & Equipment Suppliers
 Tags: construction leads, contractor leads, contractor lead classification building products supplier, trigger leads, building permit, permit database, construction project leads
 Authors: Ruoji Tang
 Author_image: /theme/images/team/Ruoji.svg

--- a/content/posts/hurricane-recovery.md
+++ b/content/posts/hurricane-recovery.md
@@ -3,6 +3,8 @@ subtitle: An analysis of Hurricane Harvey and Hurricane Ian through the lens of 
 date: 2025-11-17
 modified: 2025-11-17
 category: Data
+tag1: Natural Disaster
+tag2:
 tags: data, hurricane, permits
 authors: Morgan Friberg
 author_image: /theme/images/team/morgan.svg

--- a/content/posts/inspectify-spotlight.md
+++ b/content/posts/inspectify-spotlight.md
@@ -3,6 +3,8 @@ Subtitle: Learn how to understand the Shovels permit data fields
 Date: 2024-11-13
 Modified: 2024-11-13
 Category: Case Study
+Tag1:
+Tag2: Real Estate
 Tags: spotlight, integration, API, inspectify
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/intro-to-shovels.md
+++ b/content/posts/intro-to-shovels.md
@@ -3,6 +3,8 @@ Subtitle: Shovels launched in November 2022 to bring more transparency into cons
 Date: 2022-11-08
 Modified: 2022-11-10
 Category: Company
+Tag1:
+Tag2:
 Tags: launch
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/introducing-red-tag.md
+++ b/content/posts/introducing-red-tag.md
@@ -3,6 +3,8 @@ subtitle: Launch of our automated permit enforcement product.
 date: 2026-04-01
 modified: 2026-04-01
 category: Company
+tag1: Decisions
+tag2:
 tags: permit data, construction, transparency, product storytelling, April Fools
 authors: Ryan Buckley
 author_image: /theme/images/team/ryan.svg

--- a/content/posts/la-wildfire-rebuild-permit-data.md
+++ b/content/posts/la-wildfire-rebuild-permit-data.md
@@ -3,6 +3,8 @@ subtitle: The Palisades and Eaton fires destroyed 16,246 structures. A year of b
 date: 2026-03-17
 modified: 2026-03-17
 category: Data
+tag1: Natural Disaster
+tag2:
 tags: wildfires, California, permits, Los Angeles, construction, recovery
 authors: Morgan Friberg
 author_image: /theme/images/team/morgan.svg

--- a/content/posts/meet-charlie.md
+++ b/content/posts/meet-charlie.md
@@ -3,6 +3,8 @@ Subtitle: Natural language search for millions of building permits and contracto
 Date: 2026-01-14
 Modified: 2026-01-14
 Category: Company
+Tag1: Charlie
+Tag2:
 Tags: product, AI, Charlie
 Authors: Morgan Friberg
 Author_image: /theme/images/team/morgan.svg

--- a/content/posts/newsletter-apr-23.md
+++ b/content/posts/newsletter-apr-23.md
@@ -2,7 +2,9 @@ Title: April 2023 Newsletter
 Subtitle: We've now raised about $1M and we're super close to releasing v2 of our prototype
 Date: 2023-4-20
 Modified: 2023-4-20
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-apr-24.md
+++ b/content/posts/newsletter-apr-24.md
@@ -2,7 +2,9 @@ Title: April 2024 Newsletter
 Subtitle: We raised over $600,000 and have a robust roadmap
 Date: 2024-4-10
 Modified: 2024-4-10
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-apr-25-afd.md
+++ b/content/posts/newsletter-apr-25-afd.md
@@ -2,7 +2,9 @@ Title: Introducing: The Department of Permit Efficiency (DOPE)
 Subtitle: A look at revolutionizing permit approvals through AI, blockchain, and executive orders
 Date: 2025-4-01
 Modified: 2025-04-01
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-apr-25.md
+++ b/content/posts/newsletter-apr-25.md
@@ -2,7 +2,9 @@ Title: April 2025 Newsletter
 Subtitle: It's Climate Week in San Francisco and we are here for it.
 Date: 2025-04-21
 Modified: 2025-04-21
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-aug-23.md
+++ b/content/posts/newsletter-aug-23.md
@@ -2,7 +2,9 @@ Title: August 2023 Newsletter
 Subtitle: Lots of API updates and new states are launching this week
 Date: 2023-8-17
 Modified: 2023-8-17
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-aug-24.md
+++ b/content/posts/newsletter-aug-24.md
@@ -2,7 +2,9 @@ Title: August 2024 Newsletter
 Subtitle: Lots of API updates and new states are launching this week
 Date: 2024-8-17
 Modified: 2024-8-17
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-aug-25.md
+++ b/content/posts/newsletter-aug-25.md
@@ -2,7 +2,9 @@ title: August 2025 Newsletter
 subtitle: Expansion, contraction, and government inbounds
 date: 2025-08-19
 modified: 2025-08-19
-category: Company
+category: Newsletter
+tag1:
+tag2:
 tags: company, expansion, government
 authors: Ryan Buckley
 author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-dec-22.md
+++ b/content/posts/newsletter-dec-22.md
@@ -2,7 +2,9 @@ Title: December 2022 Newsletter
 Subtitle: We have a better problem statement and understanding of our customers! 
 Date: 2022-12-13
 Modified: 2022-12-14
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-dec-23.md
+++ b/content/posts/newsletter-dec-23.md
@@ -2,7 +2,9 @@ Title: December 2023 Newsletter
 Subtitle: Cool new permit lookup features in the Shovels app and why we're going long on climate
 Date: 2023-12-5
 Modified: 2023-12-5
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-dec-24.md
+++ b/content/posts/newsletter-dec-24.md
@@ -2,7 +2,9 @@ Title: December 2024 Newsletter
 Subtitle: Cool new permit lookup features in the Shovels app and why we're going long on climate
 Date: 2024-12-19
 Modified: 2024-12-19
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-feb-23.md
+++ b/content/posts/newsletter-feb-23.md
@@ -2,7 +2,9 @@ Title: February 2023 Newsletter
 Subtitle: We raised money and increased prices!
 Date: 2023-2-16
 Modified: 2023-2-16
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-feb-24.md
+++ b/content/posts/newsletter-feb-24.md
@@ -2,7 +2,9 @@ Title: February 2024 Newsletter
 Subtitle: Announcing the first major release of our software product!
 Date: 2024-2-12
 Modified: 2024-2-12
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company,newsletter
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-feb-25.md
+++ b/content/posts/newsletter-feb-25.md
@@ -2,7 +2,9 @@ Title: February 2025 Newsletter
 Subtitle: Revolutionizing construction intelligence with powerful new features and insights
 Date: 2025-02-13
 Modified: 2025-02-13
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company,newsletter
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-feb-26.md
+++ b/content/posts/newsletter-feb-26.md
@@ -2,7 +2,9 @@ Title: February 2026 Newsletter
 Subtitle: How Shovels embraces AI tooling and what it means for the future of data startups
 Date: 2026-2-18
 Modified: 2026-2-18
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company,newsletter
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-jan-24 .md
+++ b/content/posts/newsletter-jan-24 .md
@@ -2,7 +2,9 @@ Title: January 2024 Newsletter
 Subtitle: With the help of ChatGPT, we are officially putting the AI in Shovels.ai
 Date: 2024-1-4
 Modified: 2024-1-4
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company,newsletter
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-jan-25.md
+++ b/content/posts/newsletter-jan-25.md
@@ -2,7 +2,9 @@ Title: January 2025 Newsletter
 Subtitle: A new year, a new website, and a new way to use Shovels.ai
 Date: 2025-1-15
 Modified: 2025-1-15
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company,newsletter
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-jan-26.md
+++ b/content/posts/newsletter-jan-26.md
@@ -2,7 +2,9 @@ Title: January 2026 Newsletter
 Subtitle: Shovels is growing up: ReZone acquisition, Charlie launch, and critical Shovels Online improvements
 Date: 2026-1-14
 Modified: 2026-1-14
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company,newsletter
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-july-23.md
+++ b/content/posts/newsletter-july-23.md
@@ -2,7 +2,9 @@ Title: July 2023 Newsletter
 Subtitle: 21M permits are now in California and early bird plans are available! 
 Date: 2023-7-24
 Modified: 2023-7-24
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-july-24.md
+++ b/content/posts/newsletter-july-24.md
@@ -2,7 +2,9 @@ Title: July 2024 Newsletter
 Subtitle: This month we started rebuilding a few things. The results are exciting!
 Date: 2024-7-10
 Modified: 2024-7-10
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-july-25.md
+++ b/content/posts/newsletter-july-25.md
@@ -2,7 +2,9 @@ title: July 2025 Newsletter
 subtitle: Shovels is now a geospatial business
 date: 2025-07-15
 modified: 2025-07-15
-category: Company
+category: Newsletter
+tag1:
+tag2:
 tags: company, geospatial, esri
 authors: Ryan Buckley
 author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-june-23.md
+++ b/content/posts/newsletter-june-23.md
@@ -2,7 +2,9 @@ Title: June 2023 Newsletter
 Subtitle: Enough with the fundraising blah blah blah. It's time to start talking about building permits! 
 Date: 2023-6-28
 Modified: 2023-6-28
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-june-24.md
+++ b/content/posts/newsletter-june-24.md
@@ -2,7 +2,9 @@ Title: June 2024 Newsletter
 Subtitle: This month we started rebuilding a few things. The results are exciting!
 Date: 2024-6-18
 Modified: 2024-6-18
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-june-25.md
+++ b/content/posts/newsletter-june-25.md
@@ -2,7 +2,9 @@ Title: June 2025 Newsletter
 Subtitle: We raised $5M and launched Project Wolverine
 Date: 2025-6-10
 Modified: 2025-6-10
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-mar-23.md
+++ b/content/posts/newsletter-mar-23.md
@@ -2,7 +2,9 @@ Title: March 2023 Newsletter
 Subtitle: We raised over $600,000 and have a robust roadmap
 Date: 2023-3-15
 Modified: 2023-3-15
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-mar-24.md
+++ b/content/posts/newsletter-mar-24.md
@@ -2,7 +2,9 @@ Title: March 2024 Newsletter
 Subtitle: We launched an Android app and now offer private table sharing
 Date: 2024-3-11
 Modified: 2024-3-11
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company,newsletter
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-mar-25.md
+++ b/content/posts/newsletter-mar-25.md
@@ -2,7 +2,9 @@ Title: March 2025 Newsletter
 Subtitle: Join our energy hackathon, explore new features, and discover the power of parcel-based permit analysis
 Date: 2025-03-10
 Modified: 2025-03-10
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company,newsletter
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-may-23.md
+++ b/content/posts/newsletter-may-23.md
@@ -2,7 +2,9 @@ Title: May 2023 Newsletter
 Subtitle: More on our final fundraising number and how we plan to spend it
 Date: 2023-5-24
 Modified: 2023-5-24
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-may-24.md
+++ b/content/posts/newsletter-may-24.md
@@ -2,7 +2,9 @@ Title: May 2024 Newsletter
 Subtitle: We added a new team member and are actively building our next major software release
 Date: 2024-5-13
 Modified: 2024-5-13
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-may-25.md
+++ b/content/posts/newsletter-may-25.md
@@ -2,7 +2,9 @@ Title: May 2025 Newsletter
 Subtitle: Discover new API features and company milestones!
 Date: 2025-5-16
 Modified: 2025-5-16
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-nov-25.md
+++ b/content/posts/newsletter-nov-25.md
@@ -2,7 +2,9 @@ title: November 2025 Newsletter
 subtitle: A retrospective on 2025: Doubled coverage, tripled revenue, and building the intelligence layer for the built world
 date: 2025-11-20
 modified: 2025-11-20
-category: Company
+category: Newsletter
+tag1:
+tag2:
 tags: company,newsletter
 authors: Ryan Buckley
 author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-oct-23.md
+++ b/content/posts/newsletter-oct-23.md
@@ -2,7 +2,9 @@ Title: October 2023 Newsletter
 Subtitle: The Shovels API is live and self-serve! 
 Date: 2023-10-17
 Modified: 2023-10-17
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-oct-24.md
+++ b/content/posts/newsletter-oct-24.md
@@ -2,7 +2,9 @@ Title: October 2024 Newsletter
 Subtitle: 150M permits at your fingertips 
 Date: 2024-10-9
 Modified: 2024-10-9
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-oct-25.md
+++ b/content/posts/newsletter-oct-25.md
@@ -2,7 +2,9 @@ title: October 2025 Newsletter
 subtitle: Big data, bigger ambitions: Announcing new milestones, teams, and AI at Shovels
 date: 2025-10-15
 modified: 2025-10-15
-category: Company
+category: Newsletter
+tag1:
+tag2:
 tags: company
 authors: Ryan Buckley
 author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-sep-23.md
+++ b/content/posts/newsletter-sep-23.md
@@ -2,7 +2,9 @@ Title: September 2023 Newsletter
 Subtitle: 100M permits at your disposal 
 Date: 2023-9-17
 Modified: 2023-9-17
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-sep-24.md
+++ b/content/posts/newsletter-sep-24.md
@@ -2,7 +2,9 @@ Title: September 2024 Newsletter
 Subtitle: 150M permits at your disposal
 Date: 2024-9-17
 Modified: 2024-9-17
-Category: Company
+Category: Newsletter
+Tag1:
+Tag2:
 Tags: company
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/newsletter-sep-25.md
+++ b/content/posts/newsletter-sep-25.md
@@ -2,7 +2,9 @@ title: September 2025 Newsletter
 subtitle: Expansion, contraction, and government inbounds
 date: 2025-09-16
 modified: 2025-09-16
-category: Company
+category: Newsletter
+tag1:
+tag2:
 tags: geospatial-analysis, building-permits, team-growth, SOC2-compliance, quarterly-index, data-insights, mapping, permit-data
 authors: Ryan Buckley
 author_image: /theme/images/team/ryan.svg

--- a/content/posts/over-the-counter-permits.md
+++ b/content/posts/over-the-counter-permits.md
@@ -3,6 +3,8 @@ subtitle: Learn what an over the counter permit is, which projects qualify, and 
 date: 2026-03-31
 modified: 2026-03-31
 category: Customer Success
+tag1: Construction Permits 101
+tag2:
 tags: over the counter permit, building over the counter, express permit, otc permit
 authors: Ruoji Tang
 author_image: /theme/images/team/Ruoji.svg

--- a/content/posts/permit-expediter.md
+++ b/content/posts/permit-expediter.md
@@ -3,6 +3,8 @@ subtitle: Learn what a permit expediter does, when to hire one, and how much per
 date: 2026-04-06
 modified: 2026-04-06
 category: Customer Success
+tag1: Construction Permits 101
+tag2:
 tags: Customer Success, Construction Permits 101
 authors: Ruoji Tang
 author_image: /theme/images/team/Ruoji.svg

--- a/content/posts/permit-jurisdiction-file.md
+++ b/content/posts/permit-jurisdiction-file.md
@@ -3,6 +3,8 @@ Subtitle: We are open-sourcing our database of every building permit jurisdictio
 Date: 2024-4-6
 Modified: 2024-4-6
 Category: Data
+Tag1: Construction Permits 101
+Tag2:
 Tags: building permits, AHJ, permit jurisdiction
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-1.md
+++ b/content/posts/podcast-1.md
@@ -3,6 +3,8 @@ Subtitle: We explore the pros and cons of both Bubble and FlutterFlow
 Date: 2023-9-22
 Modified: 2023-9-22
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: podcast, no-code, coding
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-10.md
+++ b/content/posts/podcast-10.md
@@ -3,6 +3,8 @@ Subtitle: Unraveling the complexities of effective email marketing in the propte
 Date: 2023-11-29
 Modified: 2023-11-29
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: podcast, email marketing, proptech
 Authors: Ryan Buckley
 author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-11.md
+++ b/content/posts/podcast-11.md
@@ -3,6 +3,8 @@ Subtitle: Unveiling the opportunities at the crossroads of real estate and envir
 Date: 2023-12-07
 Modified: 2023-12-07
 Category: Podcast
+Tag1:
+Tag2: Energy & Climate
 Tags: podcast, climatetech, proptech
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-12.md
+++ b/content/posts/podcast-12.md
@@ -3,6 +3,8 @@ Subtitle: Exploring the vital role of company culture in shaping the future of p
 Date: 2023-12-13
 Modified: 2023-12-13
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: podcast, culture, hr, proptech
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-13.md
+++ b/content/posts/podcast-13.md
@@ -3,6 +3,8 @@ Subtitle: Unpacking Legal Changes and Their Impact on Proptech
 Date: 2024-01-11
 Modified: 2024-01-11
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: podcast, culture, supreme court, proptech
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-14.md
+++ b/content/posts/podcast-14.md
@@ -3,6 +3,8 @@ Subtitle: A Tale of Two Venues: Insights from Davos and White House Discussions
 Date: 2024-01-18
 Modified: 2024-01-18
 Category: Podcast
+Tag1:
+Tag2: Energy & Climate
 Tags: podcast, culture, davos, energy, permit data
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-15.md
+++ b/content/posts/podcast-15.md
@@ -3,6 +3,8 @@ Subtitle: Exploring the intersection of zoning laws and technology in shaping th
 Date: 2024-01-29
 Modified: 2024-01-29
 Category: Podcast
+Tag1: Zoning
+Tag2: Real Estate
 Tags: podcast, zoning, proptech, real estate law
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-16.md
+++ b/content/posts/podcast-16.md
@@ -3,6 +3,8 @@ Subtitle: Unpacking the complexities and strategies of securing investment in th
 Date: 2024-02-05
 Modified: 2024-02-05
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: podcast, fundraising, seed, series a, pre-seed
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-17.md
+++ b/content/posts/podcast-17.md
@@ -3,6 +3,8 @@ Subtitle: Discovering the intersections of technology and real estate through en
 Date: 2024-02-13
 Modified: 2024-02-13
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: super bowl, advertising
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-18.md
+++ b/content/posts/podcast-18.md
@@ -3,6 +3,8 @@ Subtitle: Ryan Buckley and Fernando Pizarro delve into the intricacies of outbou
 Date: 2024-02-20
 Modified: 2024-02-20
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: outbound sales, cold emails
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-19.md
+++ b/content/posts/podcast-19.md
@@ -3,6 +3,8 @@ Subtitle: Ryan Buckley and Fernando Pizarro share their favorite business books,
 Date: 2024-02-27
 Modified: 2024-02-27
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: book club, sales books, marketing books, business books
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-2.md
+++ b/content/posts/podcast-2.md
@@ -3,6 +3,8 @@ Subtitle: We discuss the opportunities and challenges fundraising in proptech in
 Date: 2023-10-01
 Modified: 2023-10-01
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: proptech, fundraising
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-3.md
+++ b/content/posts/podcast-3.md
@@ -3,6 +3,8 @@ Subtitle: Exploring strategic positioning in proptech through a bakery analogy
 Date: 2023-10-13
 Modified: 2023-10-13
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: proptech, positioning
 Authors: Ryan Buckley
 author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-4.md
+++ b/content/posts/podcast-4.md
@@ -3,6 +3,8 @@ Subtitle: Unveiling the art of effective team building in the dynamic world of p
 Date: 2023-10-20
 Modified: 2023-10-20
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: podcast, no-code, coding
 Authors: Ryan Buckley
 author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-5.md
+++ b/content/posts/podcast-5.md
@@ -3,6 +3,8 @@ Subtitle: Understanding the unique challenges and strategies in proptech sales a
 Date: 2023-10-27
 Modified: 2023-10-27
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: podcast, sales, crm
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-6.md
+++ b/content/posts/podcast-6.md
@@ -3,6 +3,8 @@ Subtitle: Exploring the transformation of urban spaces and the role of technolog
 Date: 2023-11-02
 Modified: 2023-11-02
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: podcast, downtown, economic development
 Authors: Ryan Buckley
 author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-7.md
+++ b/content/posts/podcast-7.md
@@ -3,6 +3,8 @@ Subtitle: Diving into the complexities and insights of commercial building permi
 Date: 2023-11-08
 Modified: 2023-11-08
 Category: Podcast
+Tag1: Construction Permits 101
+Tag2: Real Estate
 Tags: podcast, building permit, building contractor
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-8.md
+++ b/content/posts/podcast-8.md
@@ -3,6 +3,8 @@ Subtitle: Exploring the journey from concept to construction in proptech
 Date: 2023-11-15
 Modified: 2023-11-15
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: podcast, commercial permit, proptech
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/podcast-9.md
+++ b/content/posts/podcast-9.md
@@ -3,6 +3,8 @@ Subtitle: A deep dive into using AI for enhancing proptech strategies
 Date: 2023-11-21
 Modified: 2023-11-21
 Category: Podcast
+Tag1:
+Tag2: Real Estate
 Tags: podcast, commercial permit, proptech
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/pr-seed-round.md
+++ b/content/posts/pr-seed-round.md
@@ -3,6 +3,8 @@ Date: 2025-06-10
 Subtitle: Base10 Partners leads funding for Shovels, providing resources for next round of product development
 Modified: 2025-06-10
 Category: Company
+Tag1:
+Tag2:
 Tags: press-release
 Authors: Betty Wan
 Author_image: /theme/images/team/betty.svg

--- a/content/posts/prolific_partnership.md
+++ b/content/posts/prolific_partnership.md
@@ -3,6 +3,8 @@ Subtitle: Learn how the Shovels team built their LLM training sample.
 Date: 2024-09-26
 Modified: 2024-09-29
 Category: Company
+Tag1:
+Tag2:
 Tags: AI, Machine Learning, Partnership
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/proptech-gtm.md
+++ b/content/posts/proptech-gtm.md
@@ -2,7 +2,9 @@ Title: Go-to-market strategies for proptech companies
 Subtitle: Use building permits to create an effective go-to-market plan for proptech companies
 Date: 2023-6-22
 Modified: 2023-6-22
-Category: GTM
+Category: Customer Success
+Tag1: Lead Generation
+Tag2: Real Estate
 Tags: gtm, building permits
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/rezone-adu-regulations-nationwide.md
+++ b/content/posts/rezone-adu-regulations-nationwide.md
@@ -3,6 +3,8 @@ Subtitle: A One-Year Review of All ADU Legislation in the Largest 250 Cities
 Date: 2025-03-28
 Modified: 2025-09-26
 Category: Data
+Tag1: ADU Content
+Tag2:
 Tags: ADU, Accessory Dwelling Unit, zoning, housing policy, urban development, ReZone
 Authors: Daniel Heller
 Author_image: /images/rezone/Daniel-Heller.jpg

--- a/content/posts/rezone-affordable-housing-analysis.md
+++ b/content/posts/rezone-affordable-housing-analysis.md
@@ -3,6 +3,8 @@ Subtitle: Using City Council Data to Reveal Trends, Tools, and Tactics in Afford
 Date: 2024-12-20
 Modified: 2024-12-20
 Category: Data
+Tag1: Affordable Housing
+Tag2:
 Tags: affordable housing, zoning, housing policy, city council, PILOT, LIHTC, ReZone
 Authors: Daniel Heller
 Author_image: /images/rezone/Daniel-Heller.jpg

--- a/content/posts/rezone-annexations-city-analysis.md
+++ b/content/posts/rezone-annexations-city-analysis.md
@@ -3,6 +3,8 @@ Subtitle: Analyzing City Council Data
 Date: 2025-01-28
 Modified: 2025-01-28
 Category: Data
+Tag1: Zoning
+Tag2:
 Tags: ReZone, annexations, municipal planning, city council, urban development, zoning
 Authors: Daniel Heller
 Author_image: /images/rezone/Daniel-Heller.jpg

--- a/content/posts/rezone-infrastructure-development-analysis.md
+++ b/content/posts/rezone-infrastructure-development-analysis.md
@@ -3,6 +3,8 @@ Subtitle: Using City Council Data to Examine Trends in Infrastructure Planning
 Date: 2025-01-14
 Modified: 2025-01-14
 Category: Data
+Tag1: Zoning
+Tag2:
 Tags: ReZone, infrastructure, city council, urban development, municipal planning, TIF, water management
 Authors: Daniel Heller
 Author_image: /images/rezone/Daniel-Heller.jpg

--- a/content/posts/rezone-local-land-use-april.md
+++ b/content/posts/rezone-local-land-use-april.md
@@ -3,6 +3,8 @@ Subtitle: Tracking the latest city council decisions shaping urban development n
 Date: 2025-04-22
 Modified: 2025-04-22
 Category: Data
+Tag1: Zoning
+Tag2:
 Tags: ReZone, zoning, city council, urban development, Seattle, Austin, Long Beach, inclusionary zoning
 Authors: Daniel Heller
 Author_image: /images/rezone/Daniel-Heller.jpg

--- a/content/posts/rezone-local-land-use-march-update.md
+++ b/content/posts/rezone-local-land-use-march-update.md
@@ -3,6 +3,8 @@ Subtitle: Discover the latest city council decisions shaping urban development n
 Date: 2025-03-13
 Modified: 2025-03-13
 Category: Data
+Tag1: Zoning
+Tag2:
 Tags: ReZone, zoning, city council, urban development, Omaha, Newark, Columbus, annexation
 Authors: Daniel Heller
 Author_image: /images/rezone/Daniel-Heller.jpg

--- a/content/posts/rezone-mixed-use-arizona.md
+++ b/content/posts/rezone-mixed-use-arizona.md
@@ -3,6 +3,8 @@ Subtitle: Analyzing all city decisions in AZ to explore mixed-use developments a
 Date: 2025-02-24
 Modified: 2025-02-24
 Category: Data
+Tag1: Zoning
+Tag2:
 Tags: ReZone, zoning, mixed-use, Arizona, urban development, walkability, adaptive reuse
 Authors: Daniel Heller
 Author_image: /images/rezone/Daniel-Heller.jpg

--- a/content/posts/rezone-student-housing.md
+++ b/content/posts/rezone-student-housing.md
@@ -3,6 +3,8 @@ Subtitle: A six-month review of all student-housing legislation in the largest 2
 Date: 2025-05-12
 Modified: 2025-05-12
 Category: Data
+Tag1: Affordable Housing
+Tag2:
 Tags: ReZone, student housing, zoning, city council, urban development, PBSA, affordable housing
 Authors: Daniel Heller
 Author_image: /images/rezone/Daniel-Heller.jpg

--- a/content/posts/san-diego-solar-density.md
+++ b/content/posts/san-diego-solar-density.md
@@ -3,6 +3,8 @@ Subtitle: Analyzing Census Tracts in San Diego
 Date: 2025-04-09
 Modified: 2025-04-09
 Category: Data
+Tag1: Solar & EV
+Tag2: Energy & Climate
 Tags: solar, building permits, solar density, policy
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/shovels-101-address-permit-history.md
+++ b/content/posts/shovels-101-address-permit-history.md
@@ -3,6 +3,8 @@ Subtitle: The definitive guide to using the Shovels API to find address permit h
 Date: 2024-08-29
 Modified: 2024-11-04
 Category: Customer Success
+Tag1: API
+Tag2:
 Tags: api
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/shovels-101-maximizing-shovels-online.md
+++ b/content/posts/shovels-101-maximizing-shovels-online.md
@@ -3,6 +3,8 @@ Subtitle: In-depth tutorial on how to get the most of our your Shovels Online su
 Date: 2024-11-20
 Modified: 2024-11-20
 Category: Customer Success
+Tag1: Shovels Online
+Tag2:
 Tags: web application, tutorial
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/shovels-101-permit-fields.md
+++ b/content/posts/shovels-101-permit-fields.md
@@ -3,6 +3,8 @@ Subtitle: Learn how to understand the Shovels permit data fields
 Date: 2024-10-09
 Modified: 2024-10-09
 Category: Customer Success
+Tag1: Construction Permits 101
+Tag2:
 Tags: permits, tutorial, resource
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/shovels-101-permit-statuses.md
+++ b/content/posts/shovels-101-permit-statuses.md
@@ -3,6 +3,8 @@ Subtitle: The definitive guide to understanding Shovels Permit Statuses
 Date: 2024-09-03
 Modified: 2025-05-13
 Category: Customer Success
+Tag1: Construction Permits 101
+Tag2:
 Tags: permit status, web app
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/shovels-acquires-rezone.md
+++ b/content/posts/shovels-acquires-rezone.md
@@ -3,6 +3,8 @@ Subtitle: Acquisition expands Shovels' platform to unify government meeting deci
 Date: 2026-01-07
 Modified: 2026-01-07
 Category: Company
+Tag1: Zoning
+Tag2:
 Tags: rezone, acquisition, company news, growth
 Authors: Morgan Friberg
 Author_image: /theme/images/team/morgan.svg

--- a/content/posts/shovels-ai-categories.md
+++ b/content/posts/shovels-ai-categories.md
@@ -3,6 +3,8 @@ Subtitle: The overview of using AI to power the Shovels platform.
 Date: 2025-04-29
 Modified: 2025-04-29
 Category: Company
+Tag1:
+Tag2:
 Tags: AI, permits, data
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/shovels-cherre-announcement.md
+++ b/content/posts/shovels-cherre-announcement.md
@@ -3,6 +3,8 @@ Subtitle: Combine construction insights with internal financial and operational 
 Date: 2025-02-18
 Modified: 2025-02-20
 Category: Company
+Tag1:
+Tag2: Real Estate
 Tags: Partnership
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/shovels-clay-guide.md
+++ b/content/posts/shovels-clay-guide.md
@@ -3,6 +3,8 @@ Date: 2025-06-07
 Subtitle: Automate construction industry prospecting with Shovels API and Clay
 Modified: 2025-06-07
 Category: Company
+Tag1: Lead Generation
+Tag2:
 Tags: lead-generation, automation, api-integration, clay, construction-industry, sales-automation, prospecting
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/shovels-cli.md
+++ b/content/posts/shovels-cli.md
@@ -3,6 +3,8 @@ subtitle: Built for AI agents, power users, and anyone who prefers a terminal to
 date: 2026-03-04
 modified: 2026-03-04
 category: Product
+tag1: API
+tag2:
 tags: CLI, API, developer, AI agents, permits
 authors: Morgan Friberg
 author_image: /theme/images/team/morgan.svg

--- a/content/posts/shovels-data-source-column-blog.md
+++ b/content/posts/shovels-data-source-column-blog.md
@@ -3,6 +3,8 @@ Subtitle: A guide to understanding the origin of every field in the Shovels data
 Date: 2026-02-27
 Modified: 2026-02-27
 Category: Customer Success
+Tag1: Construction Permits 101
+Tag2:
 Tags: building permit data, data dictionary, permit fields, data transparency, contractor data
 Authors: Betty Wan
 Author_image: /theme/images/team/betty.svg

--- a/content/posts/shovels-online-gtm.md
+++ b/content/posts/shovels-online-gtm.md
@@ -3,6 +3,8 @@ Subtitle: Learn best practices for leveraging the Shovels platform to enable you
 Date: 2025-04-09
 Modified: 2025-04-09
 Category: Customer Success
+Tag1: Shovels Online
+Tag2:
 Tags: Tutorial
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/shovels-regrid.md
+++ b/content/posts/shovels-regrid.md
@@ -3,6 +3,8 @@ Date: 2025-06-23
 Subtitle: Strategic partnership enables seamless integration of parcel and permit data for enhanced location intelligence
 Modified: 2025-06-23
 Category: Company
+Tag1:
+Tag2: Real Estate
 Tags: partnership, parcel-data, permit-data, data-integration, location-intelligence, real-estate, site-selection, market-analysis, geospatial-data, property-development
 Authors: Betty Wan
 Author_image: /theme/images/team/betty.svg

--- a/content/posts/spi-q1-2025.md
+++ b/content/posts/spi-q1-2025.md
@@ -3,6 +3,8 @@ Subtitle: Use building permits to create an effective go-to-market plan for prop
 Date: 2025-5-22
 Modified: 2024-5-22
 Category: Data
+Tag1: Quarterly Index
+Tag2:
 Tags: spi, permit index, contractor index
 Authors: Ryan Buckley
 Author_image: /theme/images/team/ryan.svg

--- a/content/posts/spi-q2-2025.md
+++ b/content/posts/spi-q2-2025.md
@@ -3,6 +3,8 @@ Subtitle: Tracking Construction Trends Across the United States
 Date: 2025-09-08
 Modified: 2025-09-08
 Category: Data
+Tag1: Quarterly Index
+Tag2:
 Tags: permit index, contractor index
 Authors: Morgan Friberg
 Author_image: /theme/images/team/morgan.svg

--- a/content/posts/spi-q3-2025.md
+++ b/content/posts/spi-q3-2025.md
@@ -3,6 +3,8 @@ Subtitle: Q3 2025 construction data reveals AI infrastructure buildout, renewabl
 Date: 2025-12-18
 Modified: 2025-12-18
 Category: Data
+Tag1: Quarterly Index
+Tag2:
 Tags: permit index, contractor index
 Authors: Morgan Friberg
 Author_image: /theme/images/team/morgan.svg

--- a/content/posts/storm-intro.md
+++ b/content/posts/storm-intro.md
@@ -3,6 +3,8 @@ Subtitle: While other permit data companies stop at the internet's edge, we pick
 Date: 2025-11-25
 Modified: 2025-11-25
 Category: Company
+Tag1: Construction Permits 101
+Tag2:
 Tags: storm, data, coverage, jurisdictions
 Authors: Chloe Harris
 Author_image: /theme/images/team/chloe.gif

--- a/content/posts/tactical-rebates-spotlight.md
+++ b/content/posts/tactical-rebates-spotlight.md
@@ -3,6 +3,8 @@ Subtitle: Learn how to make your construction industry go-to-market more efficie
 Date: 2025-05-20
 Modified: 2025-05-20
 Category: Case Study
+Tag1: Solar & EV
+Tag2: Energy & Climate
 Tags: spotlight, integration, API, tactical rebates
 Authors: Betty Wan
 Author_image: /theme/images/team/betty.svg

--- a/content/posts/tampa-housing-market-permit-data.md
+++ b/content/posts/tampa-housing-market-permit-data.md
@@ -3,6 +3,8 @@ subtitle: Six jurisdictions, six different stories. Here's what permit data reve
 date: 2026-03-13
 modified: 2026-03-13
 category: Data
+tag1: Florida Housing
+tag2: Real Estate
 tags: Tampa, housing market, building permits, Florida, real estate, new construction, Hillsborough County, Manatee County, market forecast
 authors: Ruoji Tang
 author_image: /theme/images/team/Ruoji.svg

--- a/content/posts/top-5-derived-metrics.md
+++ b/content/posts/top-5-derived-metrics.md
@@ -3,6 +3,8 @@ Subtitle: Learn about the most insightful construction metrics that are unique t
 Date: 2025-03-13
 Modified: 2025-03-13
 Category: Customer Success
+Tag1: Shovels Online
+Tag2:
 Tags: Metrics
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/virginia-data-center-report.md
+++ b/content/posts/virginia-data-center-report.md
@@ -3,6 +3,8 @@ Subtitle: Virginia’s Dominance in Data Center Development | Industry Trends 20
 Date: 2025-08-05
 Modified: 2025-08-05  
 Category: Data
+Tag1: Data Center
+Tag2:
 Tags: data-centers, virginia, permits, construction, infrastructure, loudoun-county, electrical, market-analysis, commercial-real-estate, technology, sterling-va, leesburg-va, contractors, power-infrastructure, market-trends
 Authors: Betty Wan  
 Author_image: /theme/images/team/betty.svg  

--- a/content/posts/wattcarbon-partnership.md
+++ b/content/posts/wattcarbon-partnership.md
@@ -3,6 +3,8 @@ Subtitle: Support climate-saving initiatives with EACs from WattCarbon
 Date: 2024-08-22
 Modified: 2024-08-22
 Category: Company
+Tag1:
+Tag2: Energy & Climate
 Tags: EAC, WattCarbon, Decarbonization
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/welcome-shovels-documentation.md
+++ b/content/posts/welcome-shovels-documentation.md
@@ -3,6 +3,8 @@ Subtitle: A brief introduction to our docs hub, including what content will stay
 Date: 2025-01-16
 Modified: 2025-01-24
 Category: Company
+Tag1:
+Tag2:
 Tags: Documentation, Tutorials, Release Notes
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/welcome-shovels-online.md
+++ b/content/posts/welcome-shovels-online.md
@@ -3,6 +3,8 @@ Subtitle: An introductory tour of the new Shovels web app, Shovels Online
 Date: 2024-11-06
 Modified: 2024-11-06
 Category: Company
+Tag1: Shovels Online
+Tag2:
 Tags: product launch, web application
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg

--- a/content/posts/welcome-to-shovels-v2.md
+++ b/content/posts/welcome-to-shovels-v2.md
@@ -3,6 +3,8 @@ Subtitle: An introduction to our upgraded API and Shovels Online platforms
 Date: 2024-10-22
 Modified: 2024-10-22
 Category: Company
+Tag1: Shovels Online
+Tag2:
 Tags: new release, api, web app
 Authors: Alex Brown
 Author_image: /theme/images/team/alex.svg


### PR DESCRIPTION
## Summary
- Adds `Tag1` (SEO cluster) and `Tag2` (industry) front matter fields to all 130 blog posts, assigned based on post content
- Renames `Category: GTM` → `Category: Customer Success` on `proptech-gtm.md` and `contech-gtm.md`
- Changes `Category: Company` → `Category: Newsletter` on all 36 `newsletter-*.md` posts

## Why are we making this change?
Establishes a consistent, structured taxonomy for SEO clustering and industry targeting across the blog. The Newsletter category change ensures the blog homepage auto-generates a Newsletter filter tab and drops the stale GTM one — both driven entirely by front matter, no template changes needed.