### PR TITLE
Rename Customers to Industries in nav and footer

### DIFF
--- a/themes/shovels/templates/footer.html
+++ b/themes/shovels/templates/footer.html
@@ -6,10 +6,10 @@
 
     <!-- Mobile Footer Accordions (visible below lg) -->
     <div class="lg:hidden space-y-0" x-data="{ customersOpen: false, solutionsOpen: false, resourcesOpen: false, companyOpen: false }">
-      <!-- Customers Accordion -->
+      <!-- Industries Accordion -->
       <div class="border-b border-gray-700">
         <button @click="customersOpen = !customersOpen" class="flex w-full items-center justify-between py-4 text-sm font-medium text-amber-300">
-          <span>Customers</span>
+          <span>Industries</span>
           <svg class="h-5 w-5 text-amber-300 transition-transform duration-200" :class="{ 'rotate-180': customersOpen }" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
           </svg>
@@ -86,7 +86,7 @@
       <div class="grid grid-cols-2 gap-8 xl:col-span-2">
         <div class="md:grid md:grid-cols-2 md:gap-8">
           <div>
-            <h3 class="text-sm leading-6 text-amber-300">Customers</h3>
+            <h3 class="text-sm leading-6 text-amber-300">Industries</h3>
             <ul role="list" class="mt-6">
               <li>
                 <a href="{{ SITEURL }}/building-materials" class="text-sm leading-6 hover:text-amber-500">Building Material Suppliers</a>

--- a/themes/shovels/templates/header.html
+++ b/themes/shovels/templates/header.html
@@ -26,7 +26,7 @@
   <nav class="hidden space-x-10 lg:flex items-center">
     <div class="relative" x-data="{ open: false }" x-on:click.outside="open = false">
       <button type="button" class="navbar_item group" @click="open = ! open">
-        <span>Customers</span>
+        <span>Industries</span>
         <!-- Item active: "text-gray-600", Item inactive: "text-gray-400" -->
         <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
@@ -350,10 +350,10 @@
 
   <!-- Navigation -->
   <nav class="px-6 py-4 flex-1">
-    <!-- Customers Accordion -->
+    <!-- Industries Accordion -->
     <div class="border-b border-gray-100">
       <button @click="customersOpen = !customersOpen" class="flex w-full items-center justify-between py-4 text-base font-semibold text-emerald-900">
-        <span>Customers</span>
+        <span>Industries</span>
         <svg class="h-5 w-5 text-gray-400 transition-transform duration-200" :class="{ 'rotate-180': customersOpen }" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
         </svg>


### PR DESCRIPTION
## Summary
- Renames "Customers" label to "Industries" in the top-level desktop nav dropdown
- Updates mobile nav accordion and footer (mobile accordion + desktop column heading) to match

## Test plan
- [ ] Desktop nav dropdown shows "Industries"
- [ ] Mobile nav accordion shows "Industries"
- [ ] Footer mobile accordion shows "Industries"
- [ ] Footer desktop column heading shows "Industries"
- [ ] All existing links within the dropdown/section are unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)