### PR TITLE
Fix V2 pagination example to cursor-based envelope

### DIFF
--- a/content/posts/api-guide-2.md
+++ b/content/posts/api-guide-2.md
@@ -145,9 +145,8 @@ The response includes a wealth of information about each permit:
     },
     ...
   ],
-  "page": 1,
   "size": 50,
-  "next_page": 2
+  "next_cursor": "<cursor>"
 }
 ```
 


### PR DESCRIPTION
## Summary

The V2 response example in `content/posts/api-guide-2.md` showed `page`/`next_page` offset fields the API never returns. Replaced with the real cursor envelope keys (`size`, `next_cursor`) so the guide matches the cursor-only API.

This is the shovels-marketing portion of MAR-120; the shovels-docs portion is in ShovelsAI/shovels-docs#26.

Fixes MAR-120

🤖 Generated with [Claude Code](https://claude.com/claude-code)