### PR TITLE
Add main landmark to contractor-directory and coverage

### DIFF
--- a/content/pages/contractor-directory.md
+++ b/content/pages/contractor-directory.md
@@ -2,6 +2,8 @@ Title: Nationwide Building Contractor API
 Description: Access our comprehensive contractor directory with service area mapping, permit history, construction speed metrics, and inspection pass rates.
 slug: contractor-directory
 
+<main>
+
 <!-- hero -->
 <section class="hero_container">
   <div class="hero_text-container">
@@ -90,3 +92,5 @@ slug: contractor-directory
     </div>
   </dl>
 </section>
+
+</main>

--- a/themes/shovels/templates/coverage.html
+++ b/themes/shovels/templates/coverage.html
@@ -140,6 +140,8 @@
 
 {% block content %}
 
+<main>
+
 <!-- Hero section -->
 <div class="mx-auto max-w-7xl px-6 lg:px-8 pt-10 lg:pt-12 pb-4">
   <div class="mx-auto max-w-4xl text-center">
@@ -227,5 +229,7 @@
 
 <!-- D3.js treemap visualization -->
 <script type="module" src="/theme/js/coverage-treemap.js"></script>
+
+</main>
 
 {% endblock %}


### PR DESCRIPTION
## Summary

Lighthouse's accessibility audit flagged "Document does not have a main landmark" on `/contractor-directory` and `/coverage`. Wrapped each page's primary content in a `<main>` element to improve screen-reader navigation.

## Changes

- `content/pages/contractor-directory.md`: wrapped the page's content sections in `<main>` (this page uses the shared `page.html` template, so the landmark is added in the content).
- `themes/shovels/templates/coverage.html`: wrapped the `content` block in `<main>` (this page uses its own template).

No template-wide change was made to `page.html`, to keep the scope to just these two pages as the ticket specifies.

Fixes MAR-137

🤖 Generated with [Claude Code](https://claude.com/claude-code)