### PR TITLE
Fix WebPage JSON-LD to use front-matter description

### DIFF
--- a/themes/shovels/templates/page.html
+++ b/themes/shovels/templates/page.html
@@ -12,12 +12,15 @@
   {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "name": "{{ page.title|striptags|e }}",
+    "name": {{ page.title|striptags|tojson }},
     "url": "https://www.shovels.ai/{{ page.url }}",
-    {% if page.summary %}
-    "description": "{{ page.summary|striptags|e }}",
-    {% elif page.description %}
-    "description": "{{ page.description|striptags|e }}",
+    {# Prefer the hand-written front-matter Description; the auto-generated
+       page.summary is the raw HTML body (gibberish for macro-built pages),
+       so it's only a fallback. tojson gives correct, script-safe JSON. #}
+    {% if page.description %}
+    "description": {{ page.description|striptags|tojson }},
+    {% elif page.summary %}
+    "description": {{ page.summary|striptags|tojson }},
     {% endif %}
     "publisher": {
       "@type": "Organization",


### PR DESCRIPTION
## What
The `WebPage` JSON-LD `description` was sourced from Pelican's auto-generated `page.summary` (the raw HTML body), so any page whose content starts with a styled element — e.g. the hero's grid-pattern `<div>` — emitted escaped markup instead of a real description. The clean front-matter `Description` was only a fallback that never ran, because `page.summary` is always present.

## Fix
- Reorder `page.html` to prefer `page.description`, falling back to `page.summary` only when no Description is set.
- Encode `name` and `description` with `|tojson` instead of `|e`, so quotes and ampersands produce valid, script-safe JSON.

## Impact
- Fixes the live `/contractor-directory` page now.
- Fixes all refreshed pages on `morgan/website-refresh-2026` once it rebases on main.
- Verified across all 28 built pages: 0 broken descriptions, 0 invalid JSON-LD blocks.
- The on-page `<meta name="description">` is unchanged (`base.html` already ordered it correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)