### PR TITLE
Add TELECOM permit category to data dictionary

### DIFF
--- a/content/pages/data-dictionary.md
+++ b/content/pages/data-dictionary.md
@@ -183,6 +183,7 @@ open_graph_image: /images/shovels-data-dictionary.png
  <tr><td class="w-[25%] py-4 pl-4 pr-3 text-sm font-mono font-medium text-gray-900 sm:pl-6">REMODEL</td><td class="w-[75%] px-3 py-4 text-sm text-gray-700">Improve property aesthetic or functionality but without structural changes or expansions</td></tr>
  <tr><td class="w-[25%] py-4 pl-4 pr-3 text-sm font-mono font-medium text-gray-900 sm:pl-6">ROOFING</td><td class="w-[75%] px-3 py-4 text-sm text-gray-700">Installation, replacement, or repair of a roof.</td></tr>
  <tr><td class="w-[25%] py-4 pl-4 pr-3 text-sm font-mono font-medium text-gray-900 sm:pl-6">SOLAR</td><td class="w-[75%] px-3 py-4 text-sm text-gray-700">Installation of solar photovoltaic or solar thermal systems.</td></tr>
+ <tr><td class="w-[25%] py-4 pl-4 pr-3 text-sm font-mono font-medium text-gray-900 sm:pl-6">TELECOM</td><td class="w-[75%] px-3 py-4 text-sm text-gray-700">Telecom-related work including fiber, phone/cable drops, utility ROW installs, cell towers, small cells, 5G, antennas, cable installation, conduit, trenching, boring, and related infrastructure.</td></tr>
  <tr><td class="w-[25%] py-4 pl-4 pr-3 text-sm font-mono font-medium text-gray-900 sm:pl-6">WATER_HEATER</td><td class="w-[75%] px-3 py-4 text-sm text-gray-700">Installation or replacement of a water heater.</td></tr>
           </tbody>
         </table>


### PR DESCRIPTION
## What

Adds a `TELECOM` row to the Permit Categories table in the data dictionary, slotted alphabetically between `SOLAR` and `WATER_HEATER`.

**Description:** Telecom-related work including fiber, phone/cable drops, utility ROW installs, cell towers, small cells, 5G, antennas, cable installation, conduit, trenching, boring, and related infrastructure.

## Why

Documents the telecom tag for the dataset so customers can discover and filter on it.

## ⚠️ Merge gate

Do **not** merge until the `TELECOM` tag is confirmed live in the production database. Publishing the dictionary entry ahead of the data would let customers filter on a category that returns nothing.

## Notes

- Pure markup/content change — no new Tailwind utility classes, so no `output.css` rebuild required.
- Reviewed locally via Pelican dev server (Permit Categories tab).